### PR TITLE
Initial version copied from loctool v14.15.0

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,10 @@
+{
+    "presets": [[
+        "@babel/preset-env", {
+            "targets": {
+                "node": "current",
+                "browsers": "cover 99.5%"
+            }
+        }
+    ]]
+}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,35 @@
+version: 2.1
+jobs:
+  test:
+    parameters:
+        docker_image:
+          type: string
+          default: cimg/node:current-browsers
+    docker:
+      - image: << parameters.docker_image >>
+    steps:
+      - checkout
+      - run:
+          name: Setup
+          command: |
+            rm -rf node_modules package-lock.json
+            npm install
+      - run:
+          name: Running all unit tests
+          command: |
+            node -v
+            npm -v
+            npm run test
+
+workflows:
+  version: 2
+  test-all-node-versions:
+    jobs:
+      - test:
+          docker_image: circleci/node:10-browsers
+      - test:
+          docker_image: circleci/node:12-browsers
+      - test:
+          docker_image: circleci/node:14-browsers
+      - test:
+          docker_image: circleci/node:16-browsers

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ dist
 
 # TernJS port file
 .tern-port
+/lib/

--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>xliff</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.wst.validation.validationbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.wst.jsdt.core.jsNature</nature>
+	</natures>
+</projectDescription>

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,66 @@
+/**
+ * Gruntfile.js - build this project
+ *
+ * @license
+ * Copyright © 2021, JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = function(grunt) {
+    require('load-grunt-tasks')(grunt);
+
+    var debug = grunt.option('mode') === 'dev';
+
+    // Project configuration.
+    grunt.initConfig({
+        pkg: grunt.file.readJSON('package.json'),
+        uglify: {
+            options: {
+                banner: '/*! <%= pkg.name %> <%= grunt.template.today("yyyy-mm-dd") %> */\n'
+            },
+            build: {
+                src: 'src/*.js',
+                dest: 'lib/'
+            }
+        },
+        babel: {
+            options: {
+                sourceMap: true,
+                presets: ['@babel/preset-env'],
+                plugins: ["add-module-exports"],
+                minified: !debug
+            },
+            dist: {
+                files: [{
+                    expand: true,
+                    cwd: 'src',
+                    src: ['*.js'],
+                    dest: 'lib/',
+                    ext: '.js'
+                }]
+            }
+        },
+        clean: {
+            dist: ['lib']
+        }
+    });
+
+    // Load the plugin that provides the "uglify" task.
+    grunt.loadNpmTasks('grunt-contrib-uglify');
+
+    // Default task(s).
+    grunt.registerTask('default', ['babel']);
+    if (!debug) grunt.registerTask('uglify', ['uglify']);
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,104 @@
+{
+    "name": "xliff",
+    "version": "1.0.0",
+    "main": "./lib/index.js",
+    "module": "./src/index.js",
+    "exports": {
+        ".": {
+            "import": "./src/index.js",
+            "require": "./lib/index.js"
+        }
+    },
+    "description": "Library of code to parse and generate XLIFF files.",
+    "keywords": [
+        "internationalization",
+        "i18n",
+        "localization",
+        "l10n",
+        "globalization",
+        "g11n",
+        "xliff"
+    ],
+    "homepage": "https://github.com/iLib-js/xliff",
+    "bugs": "https://github.com/iLib-js/xliff/issues",
+    "email": "marketing@translationcircle.com",
+    "license": "Apache-2.0",
+    "author": {
+        "name": "Edwin Hoogerbeets",
+        "web": "http://www.translationcircle.com/",
+        "email": "edwin@translationcircle.com"
+    },
+    "contributors": [
+        {
+            "name": "Edwin Hoogerbeets",
+            "email": "ehoogerbeets@gmail.com"
+        },
+        {
+            "name": "Goun Lee",
+            "email": "goun.lee@lge.com"
+        }
+    ],
+    "files": [
+        "src",
+        "lib",
+        "docs",
+        "README.md",
+        "LICENSE"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "git@github.com:iLib-js/xliff.git"
+    },
+    "scripts": {
+        "build": "npm run build:prod",
+        "build:test": "npm-run-all build:dev build:web",
+        "build:data": "cd scripts ; node generate.js",
+        "build:pkg": "echo '{\"type\": \"commonjs\"}' > lib/package.json",
+        "build:prod": "grunt babel --mode=prod",
+        "build:dev": "grunt babel --mode=dev",
+        "build:web": "webpack-cli --env dev --config webpack-test.config.js",
+        "dist": "npm run build:prod ; npm pack",
+        "test:cli": "LANG=en_US.UTF8 npm-run-all build:pkg build:dev ; bash test/testSuite.sh",
+        "test:web": "LANG=en_US.UTF8 npm-run-all build:test ; open-cli ./test/testSuite.html ; open-cli ./test/testSuite.html -- firefox",
+        "test": "npm-run-all build:dev test:cli",
+        "test:all": "npm-run-all test:cli test:web",
+        "debug": "npm run build:dev ; node --inspect-brk test/testSuite.js",
+        "clean": "git clean -f -d src test; rm -rf lib *.tgz"
+    },
+    "devDependencies": {
+        "@babel/core": "^7.19.0",
+        "@babel/plugin-transform-regenerator": "^7.18.6",
+        "@babel/preset-env": "^7.19.0",
+        "@babel/register": "^7.18.9",
+        "@babel/runtime": "^7.19.0",
+        "@open-wc/webpack-import-meta-loader": "^0.4.7",
+        "assertextras": "^1.1.0",
+        "babel-loader": "^8.2.5",
+        "babel-plugin-add-module-exports": "^1.0.4",
+        "babel-plugin-module-resolver": "^4.1.0",
+        "babel-plugin-transform-import-meta": "^2.2.0",
+        "docdash": "^1.2.0",
+        "grunt": "^1.5.3",
+        "grunt-babel": "^8.0.0",
+        "grunt-cli": "^1.4.3",
+        "grunt-contrib-clean": "^2.0.1",
+        "grunt-contrib-jshint": "^3.2.0",
+        "grunt-contrib-nodeunit": "^4.0.0",
+        "grunt-contrib-uglify": "^5.2.2",
+        "jsdoc": "^3.6.11",
+        "jsdoc-to-markdown": "^7.1.1",
+        "json-stable-stringify": "^1.0.1",
+        "load-grunt-tasks": "^5.1.0",
+        "nodeunit": "^0.11.3",
+        "npm-run-all": "^4.1.5",
+        "open-cli": "^7.0.1",
+        "webpack": "^5.74.0",
+        "webpack-cli": "^4.10.0"
+    },
+    "dependencies": {
+        "ilib-common": "^1.1.3",
+        "ilib-locale": "^1.2.2",
+        "json5": "^2.2.1",
+        "xml-js": "^1.6.11"
+    }
+}

--- a/src/TranslationUnit.js
+++ b/src/TranslationUnit.js
@@ -1,0 +1,83 @@
+/*
+ * TranslationUnit.js - model a translation unit
+ *
+ * Copyright © 2022 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @class A class that represents an translation unit in an
+ * xliff file. 
+ */
+export default class TranslationUnit {
+    /**
+     * Construct a new translation unit The options may be undefined, which represents
+     * a new, clean TranslationUnit instance. The options object may also
+     * be an object with the following properties:
+     *
+     * <ul>
+     * <li><i>source</i> - source text for this unit (required)
+     * <li><i>sourceLocale</i> - the source locale spec for this unit (required)
+     * <li><i>target</i> - target text for this unit (optional)
+     * <li><i>targetLocale</i> - the target locale spec for this unit (optional)
+     * <li><i>key</i> - the unique resource key for this translation unit (required)
+     * <li><i>file</i> - path to the original source code file that contains the
+     * source text of this translation unit (required)
+     * <li><i>project</i> - the project that this string/unit is part of
+     * <li><i>resType</i> - type of this resource (string, array, plural) (optional)
+     * <li><i>state</i> - the state of the current unit (optional)
+     * <li><i>comment</i> - the translator's comment for this unit (optional)
+     * <li><i>datatype</i> - the source of the data of this unit (optional)
+     * <li><i>flavor</i> - the flavor that this string comes from(optional)
+     * </ul>
+     *
+     * If the required properties are not given, the constructor throws an exception.<p>
+     *
+     * For newly extracted strings, there is no target text yet. There must be a target
+     * locale for the translators to use when creating new target text, however. This
+     * means that there may be multiple translation units in a file with the same
+     * source locale and no target text, but different target locales.
+     *
+     * @constructor
+     * @param {Object|undefined} options options to
+     * initialize the unit, or undefined for a new empty unit
+     */
+    constructor(options) {
+        if (options) {
+            const everything = ["source", "sourceLocale", "key", "file", "project"].every((p) => {
+                return typeof(options[p]) !== "undefined";
+            });
+    
+            if (!everything) {
+                const missing = ["source", "sourceLocale", "key", "file", "project"].filter((p) => {
+                    return typeof(options[p]) === "undefined";
+                });
+                throw new Error(`Missing required parameters in the TranslationUnit constructor: ${missing.join(", ")}`);
+            }
+    
+            for (let p in options) {
+                this[p] = options[p];
+            }
+        }
+    }
+
+    /**
+     * Clone the current unit and return the clone.
+     * @returns {TranslationUnit} a clone of the current unit.
+     */
+    clone() {
+        return new TranslationUnit(this);
+    }
+}

--- a/src/Xliff.js
+++ b/src/Xliff.js
@@ -79,9 +79,9 @@ function generatePluralComment(res, sourcePlurals, form) {
  * @private
  */
 function versionString(num) {
-    parts = ("" + num).split(".");
-    integral = parts[0].toString();
-    fraction = parts[1] || "0";
+    const parts = ("" + num).split(".");
+    const integral = parts[0].toString();
+    const fraction = parts[1] || "0";
     return integral + '.' + fraction;
 }
 
@@ -248,7 +248,7 @@ export default class Xliff {
      */
     addTranslationUnits(units) {
         units.forEach((unit) => {
-            this.addTranslationUnit(units[i]);
+            this.addTranslationUnit(unit);
         });
     }
 
@@ -263,11 +263,12 @@ export default class Xliff {
 
     /**
      * Serialize this xliff instance as an xliff 1.2 string.
-     * @param {Array.<TranslationUnit>} units an array of units to convert to a string
      * @return {String} the current instance encoded as an xliff 1.2
      * format string
      */
-    toString1(units) {
+    toString1() {
+        const units = this.tu;
+
         let json = {
             xliff: {
                 _attributes: {
@@ -380,19 +381,18 @@ export default class Xliff {
 
     /**
      * Serialize this xliff instance as an xliff 2.0 string.
-     * @param {Array.<TranslationUnit>} units an array of units to convert to a string
      * @return {String} the current instance encoded as an xliff 2.0
      * format string
      */
-    toString2(units) {
+    toString2() {
         // in xliff 2.* you can only put one source/target locale combo into a file,
         // so we have to take only the units that are allowed. We will key off the
         // first translation unit
 
-        var sourceLocale = units[0].sourceLocale;
-        var targetLocale = units[0].targetLocale;
+        var sourceLocale = this.tu[0].sourceLocale;
+        var targetLocale = this.tu[0].targetLocale;
 
-        units = units.filter(function(unit) {
+        const units = this.tu.filter((unit) => {
             return unit.sourceLocale === sourceLocale && (!targetLocale || unit.targetLocale === targetLocale);
         });
 
@@ -554,15 +554,14 @@ export default class Xliff {
 
     /**
      * Serialize this xliff instance as an customized xliff 2.0 format string.
-     * @param {Array.<TranslationUnit>} units an array of units to convert to a string
      * @return {String} the current instance encoded as an customized xliff 2.0
      * format string
      */
-    toStringCustom(units) {
-        var sourceLocale = units[0].sourceLocale;
-        var targetLocale = units[0].targetLocale;
+    toStringCustom() {
+        var sourceLocale = this.tu[0].sourceLocale;
+        var targetLocale = this.tu[0].targetLocale;
 
-        units = units.filter(function(unit) {
+        const units = this.tu.filter((unit) => {
             return unit.sourceLocale === sourceLocale && (!targetLocale || unit.targetLocale === targetLocale);
         });
 
@@ -710,39 +709,7 @@ export default class Xliff {
     serialize(untranslated) {
         let units = [];
 
-        if (this.ts.size() > 0) {
-            // first convert the resources into translation units
-            const resources = this.ts.getAll();
-            let tu;
-
-            if (this.allowDups) {
-                // only look at the initial set of resources
-                const initialLength = resources.length;
-                for (let i = 0; i < initialLength; i++) {
-                    const res = resources[i];
-                    const instances = res.getInstances();
-                    if (instances && instances.length) {
-                        resources = resources.concat(instances);
-                        resources[i].instances = undefined;
-                    }
-                }
-            }
-            resources.sort((left, right) => {
-                if (typeof(left.index) === 'number' && typeof(right.index) === 'number') {
-                    return left.index - right.index;
-                }
-                if (typeof(left.id) === 'number' && typeof(right.id) === 'number') {
-                    return left.id - right.id;
-                }
-                // no ids and no indexes? Well, then don't rearrange
-                return 0;
-            });
-        }
-
-        if (this.tu && this.tu.length > 0) {
-            units = units.concat(this.tu);
-        }
-        return ((this.version < 2) ? this.toString1(units) : (this.style == "custom" ? this.toStringCustom(units): this.toString2(units)));
+        return ((this.version < 2) ? this.toString1() : (this.style == "custom" ? this.toStringCustom(): this.toString2()));
     }
 
     /**

--- a/src/Xliff.js
+++ b/src/Xliff.js
@@ -1,0 +1,994 @@
+/*
+ * Xliff.js - model an xliff file
+ *
+ * Copyright © 2016-2017, 2019-2022 HealthTap, Inc. and JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import xmljs from 'xml-js';
+import Locale from 'ilib-locale';
+import { JSUtils } from 'ilib-common';
+
+import TranslationUnit from './TranslationUnit.js';
+
+/**
+ * @private
+ * Return a string that can be used as an HTML attribute value.
+ * @param {string} str the string to escape
+ * @returns {string} the escaped string
+ */
+function escapeAttr(str) {
+    if (!str) return;
+    return str.
+        replace(/&/g, "&amp;").
+        replace(/"/g, "&quot;").
+        replace(/'/g, "&apos;").
+        replace(/</g, "&lt;");
+}
+
+/**
+ * @private
+ * Return the original string based on the one that was used as an attribute value.
+ * @param {string} str the string to unescape
+ * @returns {string} the unescaped string
+ */
+function unescapeAttr(str) {
+    if (!str) return;
+    return str.
+        replace(/&lt;/g, '<').
+        replace(/&quot;/g, '"').
+        replace(/&apos;/g, "'").
+        replace(/&amp;/g, "&");
+}
+
+/**
+ * @private
+ */
+function generatePluralComment(res, sourcePlurals, form) {
+    var json = {};
+
+    if (res.comment) {
+        try {
+            // see if its json already. If so, we'll add to it
+            json = JSON.parse(res.comment);
+        } catch (e) {
+            // not json, so just return it as is
+            return res.comment;
+        }
+    }
+
+    json.pluralForm = form;
+    json.pluralFormOther = res.getKey();
+
+    return JSON.stringify(json);
+}
+
+/**
+ * @private
+ */
+function versionString(num) {
+    parts = ("" + num).split(".");
+    integral = parts[0].toString();
+    fraction = parts[1] || "0";
+    return integral + '.' + fraction;
+}
+
+/**
+ * @private
+ */
+function makeArray(arrayOrObject) {
+    return Array.isArray(arrayOrObject) ? arrayOrObject : [ arrayOrObject ];
+}
+
+/**
+ * @private
+ */
+function makeTUHashKey(tu) {
+    return [tu.file, tu.sourceLocale, tu.targetLocale || "", tu.project].join("_");
+}
+
+/**
+ * @private
+ * Return true if the given locale spec is for an Asian locale that does
+ * not have spaces between words, or false for any other type of language.
+ *
+ * @param {String} spec the locale specification of the locale to test
+ * @returns {boolean} true if the given spec is for an Asian locale, or
+ * false otherwise
+ */
+function isAsianLocale(spec) {
+    var locale = new Locale(spec);
+    switch (locale.getLanguage()) {
+        case 'zh':
+        case 'ja':
+        case 'th':
+            return true;
+        default:
+            return false;
+    }
+}
+
+/**
+ * @class A class that represents an xliff file. Xliff stands for Xml 
+ * Localization Interchange File Format.
+ */
+export default class Xliff {
+
+    /**
+     * Construct a new Xliff instance. The options may be undefined,
+     * which represents a new, clean Xliff instance. The options object may also
+     * be an object with any of the following properties:
+     *
+     * <ul>
+     * <li><i>tool-id</i> - the id of the tool that saved this xliff file
+     * <li><i>tool-name</i> - the full name of the tool that saved this xliff file
+     * <li><i>tool-version</i> - the version of the tool that save this xliff file
+     * <li><i>tool-company</i> - the name of the company that made this tool
+     * <li><i>copyright</i> - a copyright notice that you would like included into the xliff file
+     * <li><i>sourceLocale</i> - specify the default source locale if a resource doesn't have a locale itself
+     * <li><i>allowDups</i> - allow duplicate resources in the xliff. By default, dups are
+     * filtered out. This option allows you to have trans-units that represent instances of the
+     * same resource in the file with different metadata. For example, two instances of a
+     * resource may have different comments which may both be useful to translators or
+     * two instances of the same resource may have been extracted from different source files.
+     * <li><i>version</i> - The version of xliff that will be produced by this instance.
+     * </ul>
+     *
+     * @constructor
+     * @param {Array.<Object>|undefined} options options to
+     * initialize the file, or undefined for a new empty file
+     */
+    constructor(options) {
+        this.version = 1.2;
+
+        if (options) {
+            this["tool-id"] = options["tool-id"];
+            this["tool-name"] = options["tool-name"];
+            this["tool-version"] = options["tool-version"];
+            this["tool-company"] = options["tool-company"];
+            this.copyright = options.copyright;
+            this.path = options.path;
+            this.sourceLocale = options.sourceLocale;
+            this.project = options.project;
+            this.allowDups = options.allowDups;
+            this.style =  options.style || "standard";
+            if (typeof(options.version) !== 'undefined') {
+                this.version = Number.parseFloat(options.version);
+            }
+        }
+
+        this.sourceLocale = this.sourceLocale || "en-US";
+
+        // place to store the translation units
+        this.tu = [];
+        this.tuhash = {};
+    }
+
+    /**
+     * @private
+     * @param project
+     * @param context
+     * @param sourceLocale
+     * @param targetLocale
+     * @param key
+     * @param type
+     * @param path
+     * @returns
+     */
+    _hashKey(project, context, sourceLocale, targetLocale, key, type, path, ordinal, quantity, flavor) {
+        const hashkey = [key, type || "string", sourceLocale || this.sourceLocale, targetLocale || "", context || "", project, path || "", ordinal || "", quantity || "", flavor || ""].join("_");
+        return hashkey;
+    }
+
+    /**
+     * Get the translation units in this xliff.
+     *
+     * @returns {Array.<Object>} the translation units in this xliff
+     */
+    getTranslationUnits() {
+        return this.tu;
+    }
+
+    /**
+     * Add this translation unit to this xliff.
+     *
+     * @param {TranslationUnit} unit the translation unit to add to this xliff
+     */
+    addTranslationUnit = function(unit) {
+        // console.log("Xliff " + this.path + ": Adding translation unit: " + JSON.stringify(unit, undefined, 4));
+
+        var hashKeySource = this._hashKey(unit.project, unit.context, unit.sourceLocale, "", unit.key, unit.resType, unit.file, unit.ordinal, unit.quantity, unit.flavor),
+            hashKeyTarget = this._hashKey(unit.project, unit.context, unit.sourceLocale, unit.targetLocale, unit.key, unit.resType, unit.file, unit.ordinal, unit.quantity, unit.flavor);
+
+        if (unit.targetLocale) {
+            var oldUnit = this.tuhash[hashKeySource];
+            if (oldUnit) {
+                // console.log("Replacing old source-only unit in favour of this joint source/target unit");
+                this.tuhash[hashKeySource] = undefined;
+                JSUtils.shallowCopy(unit, oldUnit);
+                this.tuhash[hashKeyTarget] = oldUnit;
+                return;
+            }
+        }
+
+        var oldUnit = this.tuhash[hashKeyTarget];
+        if (oldUnit && !this.allowDups) {
+            // console.log("Merging unit");
+            // update the old unit with this new info
+            JSUtils.shallowCopy(unit, oldUnit);
+        } else {
+            if (this.version >= 2 && this.tu.length) {
+                if (this.tu[0].targetLocale !== unit.targetLocale) {
+                    throw "Mismatched target locale";
+                }
+            }
+
+            // console.log("Adding new unit");
+            this.tu.push(unit);
+            this.tuhash[hashKeyTarget] = unit;
+        }
+    }
+
+    /**
+     * Add translation units to this xliff.
+     *
+     * @param {Array.<Object>} files the translation units to add to this xliff
+     */
+    addTranslationUnits(units) {
+        units.forEach((unit) => {
+            this.addTranslationUnit(units[i]);
+        });
+    }
+
+    /**
+     * Return the number of translation units in this xliff file.
+     *
+     * @return {number} the number of translation units in this xliff file
+     */
+    size() {
+        return this.tu.length;
+    }
+
+    /**
+     * Serialize this xliff instance as an xliff 1.2 string.
+     * @param {Array.<TranslationUnit>} units an array of units to convert to a string
+     * @return {String} the current instance encoded as an xliff 1.2
+     * format string
+     */
+    toString1(units) {
+        let json = {
+            xliff: {
+                _attributes: {
+                    version: versionString(this.version)
+                }
+            }
+        };
+
+        // console.log("Units to write out is " + JSON.stringify(units, undefined, 4));
+
+        // now finally add each of the units to the json
+
+        let files = {};
+        let index = 1;
+
+        for (var i = 0; i < units.length; i++) {
+            let tu = units[i];
+            if (!tu) {
+                console.log("undefined?");
+            }
+            var hashKey = makeTUHashKey(tu);
+            var file = files[hashKey];
+            if (!file) {
+                files[hashKey] = file = {
+                    _attributes: {
+                        "original": tu.file,
+                        "source-language": tu.sourceLocale,
+                        "target-language": tu.targetLocale,
+                        "product-name": tu.project,
+                        "x-flavor": tu.flavor
+                    }
+                };
+                if (this["tool-id"] || this["tool-name"] || this["tool-version"] || this["tool-company"] ||  this["company"]) {
+                    file.header = {
+                        "tool": {
+                            _attributes: {
+                                "tool-id": this["tool-id"],
+                                "tool-name": this["tool-name"],
+                                "tool-version": this["tool-version"],
+                                "tool-company": this["tool-company"],
+                                "copyright": this["copyright"]
+                            }
+                        }
+                    };
+                }
+                file.body = {};
+            }
+
+            var tujson = {
+                _attributes: {
+                    "id": (tu.id || index++),
+                    "resname": escapeAttr(tu.key),
+                    "restype": tu.resType || "string",
+                    "datatype": tu.datatype
+                },
+                "source": {
+                    "_text": tu.source
+                }
+            };
+
+            if (tu.id && tu.id > index) {
+                index = tu.id + 1;
+            }
+
+            if (tu.resType === "plural") {
+                tujson._attributes.extype = tu.quantity || "other";
+            }
+            if (tu.resType === "array") {
+                tujson._attributes.extype = tu.ordinal;
+            }
+
+            if (tu.target) {
+                tujson.target = {
+                    _attributes: {
+                        state: tu.state
+                    },
+                    "_text": tu.target
+                };
+            }
+            if (tu.comment) {
+                tujson.note = {
+                    "_text": tu.comment
+                };
+            }
+            if (tu.context) {
+                tujson._attributes["x-context"] = tu.context;
+            }
+            if (!file.body["trans-unit"]) {
+                file.body["trans-unit"] = [];
+            }
+
+            file.body["trans-unit"].push(tujson);
+        }
+
+        // sort the file tags so that they come out in the same order each time
+        if (!json.xliff.file) {
+            json.xliff.file = [];
+        }
+        Object.keys(files).sort().forEach(function(fileHashKey) {
+            json.xliff.file.push(files[fileHashKey]);
+        });
+
+        // logger.trace("json is " + JSON.stringify(json, undefined, 4));
+
+        return '<?xml version="1.0" encoding="utf-8"?>\n' + xmljs.js2xml(json, {
+            compact: true,
+            spaces: 2
+        });
+    }
+
+    /**
+     * Serialize this xliff instance as an xliff 2.0 string.
+     * @param {Array.<TranslationUnit>} units an array of units to convert to a string
+     * @return {String} the current instance encoded as an xliff 2.0
+     * format string
+     */
+    toString2(units) {
+        // in xliff 2.* you can only put one source/target locale combo into a file,
+        // so we have to take only the units that are allowed. We will key off the
+        // first translation unit
+
+        var sourceLocale = units[0].sourceLocale;
+        var targetLocale = units[0].targetLocale;
+
+        units = units.filter(function(unit) {
+            return unit.sourceLocale === sourceLocale && (!targetLocale || unit.targetLocale === targetLocale);
+        });
+
+        let json = {
+            xliff: {
+                _attributes: {
+                    "version": versionString(this.version),
+                    "srcLang": sourceLocale,
+                }
+            }
+        };
+
+        if (targetLocale) {
+            json.xliff._attributes.trgLang = targetLocale;
+        }
+
+        json.xliff._attributes["xmlns:l"] = "http://ilib-js.com/loctool";
+
+        // console.log("Units to write out is " + JSON.stringify(units, undefined, 4));
+
+        // now finally add each of the units to the json
+
+        let files = {};
+        let index = 1;
+        let datatype;
+        let groupIndex = 1;
+
+        for (var i = 0; i < units.length; i++) {
+            let tu = units[i];
+            if (!tu) {
+                console.log("undefined?");
+            }
+            let hashKey = makeTUHashKey(tu);
+            let file = files[hashKey];
+            if (!file) {
+                files[hashKey] = file = {
+                    _attributes: {
+                        "original": tu.file,
+                        "l:project": tu.project,
+                        "l:flavor": tu.flavor
+                    },
+                    group : [
+                        {
+                            _attributes: {
+                                "id": "group_" + groupIndex++,
+                                "name": tu.datatype || "plaintext"
+                            },
+                            unit: []
+                        }
+                    ]
+                };
+                if (this["tool-id"] || this["tool-name"] || this["tool-version"] || this["tool-company"] ||  this["company"]) {
+                    file.header = {
+                        "tool": {
+                            _attributes: {
+                                "tool-id": this["tool-id"],
+                                "tool-name": this["tool-name"],
+                                "tool-version": this["tool-version"],
+                                "tool-company": this["tool-company"],
+                                "copyright": this["copyright"]
+                            }
+                        }
+                    };
+                }
+            }
+
+            var tujson = {
+                _attributes: {
+                    "id": (tu.id || index++),
+                    "name": (tu.source !== tu.key) ? escapeAttr(tu.key) : undefined,
+                    "type": "res:" + (tu.resType || "string"),
+                    "l:datatype": tu.datatype
+                }
+            };
+
+            if (tu.comment) {
+                tujson.notes = {
+                    "note": [
+                        {
+                            _attributes: {
+                                "appliesTo": "source"
+                            },
+                            "_text": tu.comment
+                        }
+                    ]
+                };
+            }
+
+            tujson.segment = [
+                {
+                    "source": {
+                        "_text": tu.source
+                    }
+                }
+            ];
+
+            if (tu.id && tu.id > index) {
+                index = tu.id + 1;
+            }
+
+            if (tu.resType === "plural") {
+                tujson._attributes["l:category"] = tu.quantity || "other";
+            }
+            if (tu.resType === "array") {
+                tujson._attributes["l:index"] = tu.ordinal;
+            }
+
+            if (tu.target) {
+                tujson.segment[0].target = {
+                    _attributes: {
+                        state: tu.state,
+                    },
+                    "_text": tu.target
+                };
+            }
+            if (tu.context) {
+                tujson._attributes["l:context"] = tu.context;
+            }
+
+            datatype = tujson._attributes["l:datatype"] || "plaintext";
+            if (!files[hashKey].group) {
+                files[hashKey].group = [];
+            }
+
+            var groupSet = {
+                _attributes: {},
+                unit: []
+            }
+
+            var existGroup = files[hashKey].group.filter(function(item) {
+                if (item._attributes.name === datatype) {
+                    return item;
+                }
+            });
+
+            if (existGroup.length > 0) {
+                existGroup[0].unit.push(tujson);
+            } else {
+                groupSet._attributes.id = "group_" + groupIndex++;
+                groupSet._attributes.name = datatype;
+                files[hashKey].group.push(groupSet);
+                groupSet.unit.push(tujson);
+            }
+        }
+
+        // sort the file tags so that they come out in the same order each time
+        if (!json.xliff.file) {
+            json.xliff.file = [];
+        }
+        Object.keys(files).sort().forEach(function(fileHashKey) {
+            json.xliff.file.push(files[fileHashKey]);
+        });
+
+        return '<?xml version="1.0" encoding="utf-8"?>\n' + xmljs.js2xml(json, {
+            compact: true,
+            spaces: 2
+        });
+    }
+
+    /**
+     * Serialize this xliff instance as an customized xliff 2.0 format string.
+     * @param {Array.<TranslationUnit>} units an array of units to convert to a string
+     * @return {String} the current instance encoded as an customized xliff 2.0
+     * format string
+     */
+    toStringCustom(units) {
+        var sourceLocale = units[0].sourceLocale;
+        var targetLocale = units[0].targetLocale;
+
+        units = units.filter(function(unit) {
+            return unit.sourceLocale === sourceLocale && (!targetLocale || unit.targetLocale === targetLocale);
+        });
+
+        let json = {
+            xliff: {
+                _attributes: {
+                    "version": versionString(this.version),
+                    "srcLang": sourceLocale,
+                }
+            }
+        };
+
+        if (targetLocale) {
+            json.xliff._attributes.trgLang = targetLocale;
+        }
+
+        json.xliff._attributes["xmlns:l"] = "http://ilib-js.com/loctool";
+
+        // console.log("Units to write out is " + JSON.stringify(units, undefined, 4));
+
+        // now finally add each of the units to the json
+
+        let files = {};
+        let index = 1;
+        let fileIndex = 1;
+        let datatype;
+        let groupIndex = 1;
+
+        for (let i = 0; i < units.length; i++) {
+            let tu = units[i];
+            if (!tu) {
+                console.log("undefined?");
+            }
+            let hashKey = tu.project;
+            let file = files[hashKey];
+            if (!file) {
+                files[hashKey] = file = {
+                    _attributes: {
+                        "id": tu.project + "_f" + fileIndex++,
+                        "original": tu.project
+                    },
+                    group : [
+                        {
+                            _attributes: {
+                                "id": tu.project + "_g" + groupIndex++,
+                                "name": tu.datatype || "javascript"
+                            },
+                            unit: []
+                        }
+                    ]
+                };
+            }
+
+            let tujson = {
+                _attributes: {
+                    "id": (tu.id || index++),
+                    "name": (tu.source !== tu.key) ? escapeAttr(tu.key) : undefined,
+                }
+            };
+
+            if (tu.comment) {
+                tujson.notes = {
+                    "note": [
+                        {
+                            _attributes: {
+                                "appliesTo": "source"
+                            },
+                            "_text": tu.comment
+                        }
+                    ]
+                };
+            }
+
+            tujson.segment = [
+                {
+                    "source": {
+                        "_text": tu.source
+                    }
+                }
+            ];
+
+            if (tu.id && tu.id > index) {
+                index = tu.id + 1;
+            }
+
+            if (tu.target) {
+                tujson.segment[0].target = {
+                    _attributes: {
+                        state: tu.state,
+                    },
+                    "_text": tu.target
+                };
+            }
+
+            datatype = tu.datatype || "javascript";
+            if (!files[hashKey].group) {
+                files[hashKey].group = [];
+            }
+
+            let groupSet = {
+                _attributes: {},
+                unit: []
+            }
+
+            let existGroup = files[hashKey].group.filter(function(item) {
+                if (item._attributes.name === datatype) {
+                    return item;
+                }
+            })
+
+            if (existGroup.length > 0) {
+                existGroup[0].unit.push(tujson);
+            } else {
+                groupSet._attributes.id = tu.project+ "_g" + groupIndex++;
+                groupSet._attributes.name = datatype;
+                files[hashKey].group.push(groupSet);
+                groupSet.unit.push(tujson);
+            }
+        }
+
+        // sort the file tags so that they come out in the same order each time
+        if (!json.xliff.file) {
+            json.xliff.file = [];
+        }
+        Object.keys(files).sort().forEach(function(fileHashKey) {
+            json.xliff.file.push(files[fileHashKey]);
+        });
+
+        return '<?xml version="1.0" encoding="utf-8"?>\n' + xmljs.js2xml(json, {
+            compact: true,
+            spaces: 2
+        });
+    }
+
+    /**
+     * Serialize this xliff instance to a string that contains
+     * the xliff format xml text.
+     *
+     * @param {boolean} untranslated if true, add the untranslated resources
+     * to the xliff file without target tags. Otherwiwe, untranslated
+     * resources are skipped.
+     * @return {String} the current instance encoded as an xliff format
+     * xml text
+     */
+    serialize(untranslated) {
+        let units = [];
+
+        if (this.ts.size() > 0) {
+            // first convert the resources into translation units
+            const resources = this.ts.getAll();
+            let tu;
+
+            if (this.allowDups) {
+                // only look at the initial set of resources
+                const initialLength = resources.length;
+                for (let i = 0; i < initialLength; i++) {
+                    const res = resources[i];
+                    const instances = res.getInstances();
+                    if (instances && instances.length) {
+                        resources = resources.concat(instances);
+                        resources[i].instances = undefined;
+                    }
+                }
+            }
+            resources.sort((left, right) => {
+                if (typeof(left.index) === 'number' && typeof(right.index) === 'number') {
+                    return left.index - right.index;
+                }
+                if (typeof(left.id) === 'number' && typeof(right.id) === 'number') {
+                    return left.id - right.id;
+                }
+                // no ids and no indexes? Well, then don't rearrange
+                return 0;
+            });
+        }
+
+        if (this.tu && this.tu.length > 0) {
+            units = units.concat(this.tu);
+        }
+        return ((this.version < 2) ? this.toString1(units) : (this.style == "custom" ? this.toStringCustom(units): this.toString2(units)));
+    }
+
+    /**
+     * Parse xliff 1.* files
+     * @private
+     */
+    parse1(xliff) {
+        if (xliff.file) {
+            const files = makeArray(xliff.file);
+            let comment;
+
+            for (var i = 0; i < files.length; i++) {
+                let fileSettings = {};
+                let file = files[i];
+
+                fileSettings = {
+                    pathName: file._attributes.original,
+                    locale: file._attributes["source-language"],
+                    project: file._attributes["product-name"] || file._attributes["original"],
+                    targetLocale: file._attributes["target-language"],
+                    flavor: file._attributes["x-flavor"]
+                };
+
+                fileSettings.isAsianLocale = isAsianLocale(fileSettings.targetLocale);
+
+                if (file.body && file.body["trans-unit"]) {
+                    const units = makeArray(file.body["trans-unit"]);
+
+                    units.forEach((tu) => {
+                        if (tu.source && tu.source["_text"] && tu.source["_text"].trim().length > 0) {
+                            let targetString;
+                            if (tu.target) {
+                                if (tu.target["_text"]) {
+                                    targetString = tu.target["_text"];
+                                } else if (tu.target.mrk) {
+                                    if (Array.isArray(tu.target.mrk)) {
+                                        const targetSegments = tu.target.mrk.map((mrk) => {
+                                            return mrk["_text"];
+                                        })
+                                        targetString = targetSegments.join(fileSettings.isAsianLocale ? '' : ' ');
+                                    } else {
+                                        targetString = tu.target.mrk["_text"];
+                                    }
+                                }
+                            }
+
+                            if (!tu._attributes.resname) {
+                                if (tu.source._attributes && tu.source._attributes["x-key"]) {
+                                    tu.source["_text"] = tu.source._attributes["x-key"];
+                                    tu._attributes.resname = tu.source._attributes["x-key"];
+                                } else {
+                                    tu._attributes.resname = tu.source["_text"];
+                                }
+                            }
+
+                            try {
+                                const unit = new TranslationUnit({
+                                    file: fileSettings.pathName,
+                                    sourceLocale: fileSettings.locale,
+                                    project: fileSettings.project,
+                                    id: tu._attributes.id,
+                                    key: unescapeAttr(tu._attributes.resname),
+                                    source: tu.source["_text"],
+                                    context: tu._attributes["x-context"],
+                                    comment: comment,
+                                    targetLocale: fileSettings.targetLocale,
+                                    comment: tu.note && tu.note["_text"],
+                                    target: targetString,
+                                    resType: tu._attributes.restype,
+                                    state: tu.target && tu.target._attributes && tu.target._attributes.state,
+                                    datatype: tu._attributes.datatype,
+                                    flavor: fileSettings.flavor
+                                });
+                                switch (unit.resType) {
+                                case "array":
+                                    unit.ordinal = tu._attributes.extype && Number(tu._attributes.extype).valueOf();
+                                    break;
+                                case "plural":
+                                    unit.quantity = tu._attributes.extype;
+                                    break;
+                                }
+                                this.tu.push(unit);
+                            } catch (e) {
+                                console.log("Skipping invalid translation unit found in xliff file.\n" + e);
+                            }
+                        } else {
+                            // console.log("Found translation unit with an empty or missing source element. File: " + fileSettings.pathName + " Resname: " + tu._attributes.resname);
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    /**
+     * Parse xliff 2.* files
+     * @private
+     */
+    parse2(xliff) {
+        const sourceLocale = xliff._attributes["srcLang"] || this.project.sourceLocale;
+        const targetLocale = xliff._attributes["trgLang"];
+
+        if (xliff.file) {
+            const files = makeArray(xliff.file);
+
+            for (var i = 0; i < files.length; i++) {
+                const fileSettings = {};
+                const file = files[i];
+                const unitsElement = [];
+
+                fileSettings = {
+                    pathName: file._attributes["original"],
+                    locale: sourceLocale,
+                    project: file._attributes["l:project"] || file._attributes["original"],
+                    targetLocale: targetLocale,
+                    flavor: file._attributes["l:flavor"]
+                };
+
+                unitsElement = (typeof (file["group"]) != 'undefined') ? file.group : file;
+                unitsElement = makeArray(unitsElement);
+
+                for (let j = 0; j < unitsElement.length; j++) {
+                    if (unitsElement[j].unit) {
+                        var transUnits = makeArray(unitsElement[j].unit);
+                        var unitElementName = unitsElement[j]["_attributes"].name;
+                        transUnits.forEach(function(tu) {
+                            let comment, state;
+                            const datatype = tu._attributes["l:datatype"] || unitElementName;
+                            let source = "", target = "";
+
+                            if (tu.notes && tu.notes.note) {
+                                comment = Array.isArray(tu.notes.note) ?
+                                    tu.notes.note[0]["_text"] :
+                                    tu.notes.note["_text"];
+                            }
+
+                            const resname = tu._attributes.name;
+                            const restype = "string";
+                            if (tu._attributes.type && tu._attributes.type.startsWith("res:")) {
+                                restype = tu._attributes.type.substring(4);
+                            }
+
+                            if (tu.segment) {
+                                const segments = makeArray(tu.segment);
+                                for (var j = 0; j < segments.length; j++) {
+                                    const segment = segments[j];
+
+                                    if (segment.source["_text"]) {
+                                        source += segment.source["_text"];
+                                        if (segment.target) {
+                                            target += segment.target["_text"];
+
+                                            if (segment.target.state) {
+                                                state = segment.target._attributes.state;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            if (!resname) {
+                                resname = source;
+                            }
+
+                            if (source.trim()) {
+                                try {
+                                    const unit = new TranslationUnit({
+                                        file: fileSettings.pathName,
+                                        sourceLocale: fileSettings.locale,
+                                        project: fileSettings.project,
+                                        id: tu._attributes.id,
+                                        key: unescapeAttr(resname),
+                                        source: source,
+                                        context: tu._attributes["l:context"],
+                                        comment: comment,
+                                        targetLocale: targetLocale,
+                                        target: target,
+                                        resType: restype,
+                                        state: state,
+                                        datatype: datatype,
+                                        flavor: fileSettings.flavor
+                                    });
+                                    switch (restype) {
+                                    case "array":
+                                        unit.ordinal = tu._attributes["l:index"] && Number(tu._attributes["l:index"]).valueOf();
+                                        break;
+                                    case "plural":
+                                        unit.quantity = tu._attributes["l:category"];
+                                        break;
+                                    }
+                                    this.tu.push(unit);
+                                } catch (e) {
+                                    console.log("Skipping invalid translation unit found in xliff file.\n" + e);
+                                }
+                            } else {
+                                // console.log("Found translation unit with an empty or missing source element. File: " + fileSettings.pathName + " Resname: " + tu.resname);
+                            }
+                        }.bind(this));
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Deserialize the given string as an xml file in xliff format
+     * into this xliff instance. If there are any existing translation
+     * units already in this instance, they will be removed first.
+     *
+     * @param {String} xml the xliff format text to parse
+     */
+    deserialize(xml) {
+        const json = xmljs.xml2js(xml, {
+            trim: false,
+            nativeTypeAttribute: true,
+            compact: true
+        });
+
+        // logger.trace("json is " + JSON.stringify(json, undefined, 4));
+        this.ts = new TranslationSet(this.sourceLocale);
+
+        if (json.xliff) {
+            if (!json.xliff._attributes || !json.xliff._attributes.version ||
+                    (!json.xliff._attributes.version.startsWith("1") && !json.xliff._attributes.version.startsWith("2"))) {
+                // console.log("Unknown xliff version " + json.xliff._attributes.version + ". Cannot continue parsing.");
+                return;
+            }
+
+            if (json.xliff._attributes.version.startsWith("1")) {
+                this.parse1(json.xliff);
+            } else {
+                this.parse2(json.xliff);
+            }
+        }
+
+        return this.ts;
+    };
+
+    /**
+     * Return the version of this xliff file. If you deserialize a string into this
+     * instance of Xliff, the version will be reset to whatever is found inside of
+     * the xliff file.
+     *
+     * @returns {String} the version of this xliff
+     */
+    getVersion() {
+        return this.version || "1.2";
+    }
+}

--- a/src/Xliff.js
+++ b/src/Xliff.js
@@ -809,16 +809,16 @@ export default class Xliff {
      * @private
      */
     parse2(xliff) {
-        const sourceLocale = xliff._attributes["srcLang"] || this.project.sourceLocale;
+        const sourceLocale = xliff._attributes["srcLang"] || "en-US";
         const targetLocale = xliff._attributes["trgLang"];
 
         if (xliff.file) {
             const files = makeArray(xliff.file);
 
             for (var i = 0; i < files.length; i++) {
-                const fileSettings = {};
+                let fileSettings = {};
                 const file = files[i];
-                const unitsElement = [];
+                let unitsElement = [];
 
                 fileSettings = {
                     pathName: file._attributes["original"],
@@ -827,6 +827,8 @@ export default class Xliff {
                     targetLocale: targetLocale,
                     flavor: file._attributes["l:flavor"]
                 };
+
+                fileSettings.isAsianLocale = isAsianLocale(fileSettings.targetLocale);
 
                 unitsElement = (typeof (file["group"]) != 'undefined') ? file.group : file;
                 unitsElement = makeArray(unitsElement);
@@ -847,7 +849,7 @@ export default class Xliff {
                             }
 
                             const resname = tu._attributes.name;
-                            const restype = "string";
+                            let restype = "string";
                             if (tu._attributes.type && tu._attributes.type.startsWith("res:")) {
                                 restype = tu._attributes.type.substring(4);
                             }
@@ -860,8 +862,18 @@ export default class Xliff {
                                     if (segment.source["_text"]) {
                                         source += segment.source["_text"];
                                         if (segment.target) {
-                                            target += segment.target["_text"];
-
+                                            if (segment.target["_text"]) {
+                                                target += segment.target["_text"];
+                                            } else if (segment.target.mrk) {
+                                                if (Array.isArray(segment.target.mrk)) {
+                                                    const targetSegments = segment.target.mrk.map((mrk) => {
+                                                        return mrk["_text"];
+                                                    })
+                                                    target += targetSegments.join(fileSettings.isAsianLocale ? '' : ' ');
+                                                } else {
+                                                    target += segment.target.mrk["_text"];
+                                                }
+                                            }
                                             if (segment.target.state) {
                                                 state = segment.target._attributes.state;
                                             }

--- a/src/Xliff.js
+++ b/src/Xliff.js
@@ -928,9 +928,6 @@ export default class Xliff {
             compact: true
         });
 
-        // logger.trace("json is " + JSON.stringify(json, undefined, 4));
-        this.ts = new TranslationSet(this.sourceLocale);
-
         if (json.xliff) {
             if (!json.xliff._attributes || !json.xliff._attributes.version ||
                     (!json.xliff._attributes.version.startsWith("1") && !json.xliff._attributes.version.startsWith("2"))) {
@@ -945,7 +942,7 @@ export default class Xliff {
             }
         }
 
-        return this.ts;
+        return this.tu;
     };
 
     /**

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,26 @@
+/*
+ * index.js - export everything from all of the files
+ *
+ * Copyright © 2022 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Xliff from './Xliff.js';
+import TranslationUnit from './TranslationUnit.js';
+
+export {
+    Xliff,
+    TranslationUnit
+};

--- a/src/package.json
+++ b/src/package.json
@@ -1,0 +1,1 @@
+{"type": "module"}

--- a/test/nodeunit/nodeunit-qml.js
+++ b/test/nodeunit/nodeunit-qml.js
@@ -1,0 +1,561 @@
+var nodeunit = (function(){
+    var nodeunit = {};
+    var reporter = {};
+    var assert = this.assert = {};
+
+    (function(exports){
+        // 1. The assert module provides functions that throw
+        // AssertionError's when particular conditions are not met. The
+        // assert module must conform to the following interface.
+        var assert = exports;
+
+        // 2. The AssertionError is defined in assert.
+        // new assert.AssertionError({message: message, actual: actual, expected: expected})
+        assert.AssertionError = function AssertionError (options) {
+            this.name = "AssertionError";
+            this.message = options.message;
+            this.actual = options.actual;
+            this.expected = options.expected;
+            this.operator = options.operator;
+            var stackStartFunction = options.stackStartFunction || fail;
+
+            if (Error.captureStackTrace) {
+                Error.captureStackTrace(this, stackStartFunction);
+            }
+        };
+
+        // 3. All of the following functions must throw an AssertionError
+        // when a corresponding condition is not met, with a message that
+        // may be undefined if not provided.  All assertion methods provide
+        // both the actual and expected values to the assertion error for
+        // display purposes.
+
+        function fail(actual, expected, message, operator, stackStartFunction) {
+          throw new assert.AssertionError({
+            message: message,
+            actual: actual,
+            expected: expected,
+            operator: operator,
+            stackStartFunction: stackStartFunction
+            });
+        }
+
+        // 4. Pure assertion tests whether a value is truthy, as determined
+        // by !!guard.
+        // assert.ok(guard, message_opt);
+        // This statement is equivalent to assert.equal(true, guard,
+        // message_opt);. To test strictly for the value true, use
+        // assert.strictEqual(true, guard, message_opt);.
+        assert.ok = function ok(value, message) {
+            if (!!!value) fail(value, true, message, "==", assert.ok);
+        };
+
+        // 5. The equality assertion tests shallow, coercive equality with
+        // ==.
+        // assert.equal(actual, expected, message_opt);
+        assert.equal = function equal(actual, expected, message) {
+            if (actual != expected) fail(actual, expected, message, "==", assert.equal);
+        };
+
+        // 6. The non-equality assertion tests for whether two objects are not equal
+        // with != assert.notEqual(actual, expected, message_opt);
+        assert.notEqual = function notEqual(actual, expected, message) {
+          if (actual == expected) {
+            fail(actual, expected, message, "!=", assert.notEqual);
+          }
+        };
+
+        // 7. The equivalence assertion tests a deep equality relation.
+        // assert.deepEqual(actual, expected, message_opt);
+        assert.deepEqual = function deepEqual(actual, expected, message) {
+          if (!_deepEqual(actual, expected)) {
+            fail(actual, expected, message, "deepEqual", assert.deepEqual);
+          }
+        };
+
+        function _deepEqual(actual, expected) {
+            // 7.1. All identical values are equivalent, as determined by ===.
+            if (actual === expected) {
+                return true;
+            // 7.2. If the expected value is a Date object, the actual value is
+            // equivalent if it is also a Date object that refers to the same time.
+            } else if (actual instanceof Date && expected instanceof Date) {
+                return actual.getTime() === expected.getTime();
+            // 7.3. Other pairs that do not both pass typeof value == "object",
+            // equivalence is determined by ==.
+            } else if (typeof actual != 'object' && typeof expected != 'object') {
+                return actual == expected;
+            // 7.4. For all other Object pairs, including Array objects, equivalence is
+            // determined by having the same number of owned properties (as verified
+            // with Object.prototype.hasOwnProperty.call), the same set of keys
+            // (although not necessarily the same order), equivalent values for every
+            // corresponding key, and an identical "prototype" property. Note: this
+            // accounts for both named and indexed properties on Arrays.
+            } else {
+                return objEquiv(actual, expected);
+            }
+        };
+
+        function isUndefinedOrNull (value) {
+            return value === null || value === undefined;
+        };
+
+        function isArguments (object) {
+            return Object.prototype.toString.call(object) == '[object Arguments]';
+        };
+
+        /**
+        * Added for browser compatibility
+        */
+
+        var _keys = function (obj) {
+            if (Object.keys) {
+                return Object.keys(obj);
+            }
+            var keys = [];
+            for (var k in obj) {
+                if (obj.hasOwnProperty(k)) {
+                    keys.push(k);
+                }
+            }
+            return keys;
+        };
+
+        var _copy = function (obj) {
+            var nobj = {};
+            var keys = _keys(obj);
+            for (var i = 0; i <  keys.length; i += 1) {
+                nobj[keys[i]] = obj[keys[i]];
+            }
+            return nobj;
+        };
+
+        function objEquiv (a, b) {
+            if (isUndefinedOrNull(a) || isUndefinedOrNull(b))
+              return false;
+            // an identical "prototype" property.
+            if (a.prototype !== b.prototype) return false;
+            //~~~I've managed to break Object.keys through screwy arguments passing.
+            //   Converting to array solves the problem.
+            if (isArguments(a)) {
+              if (!isArguments(b)) {
+                return false;
+              }
+              a = pSlice.call(a);
+              b = pSlice.call(b);
+              return _deepEqual(a, b);
+            }
+            try{
+              var ka = _keys(a),
+                kb = _keys(b),
+                key, i;
+            } catch (e) {//happens when one is a string literal and the other isn't
+              return false;
+            }
+            // having the same number of owned properties (keys incorporates hasOwnProperty)
+            if (ka.length != kb.length)
+              return false;
+            //the same set of keys (although not necessarily the same order),
+            ka.sort();
+            kb.sort();
+            //~~~cheap key test
+            for (i = ka.length - 1; i >= 0; i--) {
+              if (ka[i] != kb[i])
+                return false;
+            }
+            //equivalent values for every corresponding key, and
+            //~~~possibly expensive deep test
+            for (i = ka.length - 1; i >= 0; i--) {
+              key = ka[i];
+              if (!_deepEqual(a[key], b[key] ))
+                 return false;
+            }
+            return true;
+        };
+
+        // 8. The non-equivalence assertion tests for any deep inequality.
+        // assert.notDeepEqual(actual, expected, message_opt);
+        assert.notDeepEqual = function notDeepEqual(actual, expected, message) {
+            if (_deepEqual(actual, expected)) {
+                fail(actual, expected, message, "notDeepEqual", assert.notDeepEqual);
+            }
+        };
+
+        // 9. The strict equality assertion tests strict equality, as determined by ===.
+        // assert.strictEqual(actual, expected, message_opt);
+        assert.strictEqual = function strictEqual(actual, expected, message) {
+          if (actual !== expected) {
+            fail(actual, expected, message, "===", assert.strictEqual);
+          }
+        };
+
+        // 10. The strict non-equality assertion tests for strict inequality, as determined by !==.
+        // assert.notStrictEqual(actual, expected, message_opt);
+        assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
+          if (actual === expected) {
+            fail(actual, expected, message, "!==", assert.notStrictEqual);
+          }
+        };
+
+        /**
+         * Return true if every element in the expected array also exists in the the actual
+         * array. The actual array may contain more elements that are not in the expected
+         * array. This implementation is very simple and not very efficient (Order(n^2)) so
+         * do not call this to compare large arrays.
+         *
+         * @param {Array.<Object>} actual The actual array to test
+         * @param {Array.<Object>} expected The array to test against
+         * @returns True if every element of the expected array exists in the actual array.
+         */
+        function isEqualIgnoringOrder(actual, expected) {
+            var found = false;
+            for (var i = 0; i < expected.length; i++) {
+                var found = false;
+                for (var j = 0; j < actual.length; j++) {
+                    try {
+                        if (_deepEqual(actual[j], expected[i])) {
+                            found = true;
+                            break;
+                        }
+                    } catch (ignored) {
+                    }
+                }
+                if (!found) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        
+        function isArray(object) {
+            return typeof(object) === 'object' && Object.prototype.toString.call(object) === '[object Array]';
+        };
+        
+        /**
+         * Performs a deep comparison of arrays, ignoring the order of the
+         * elements of the array. Essentially, this ensure that they have the same
+         * contents, possibly in a different order. Each of the elements of the
+         * array is compared with a deep equals. If this is called with objects
+         * that are not arrays, the assertion fails.
+         *
+         * @example // passing assertions
+         * assert.equalIgnoringOrder([5, 2, 8, 3], [2, 4, 5, 9]);
+         * assert.equalIgnoringOrder(["apples", "bananas", "oranges"], ["oranges", "apples", "bananas"]);
+         *
+         * @param {Object} actual The actual value
+         * @param {Object} expected The expected value
+         * @throws ArgumentsError
+         * @throws AssertionError
+         */
+        assert.equalIgnoringOrder = function(actual, expected, message) {
+            if (!isArray(expected)) {
+                fail("Invalid expected argument to equalIgnoringOrder.");
+            } else if (isArray(actual)) {
+                if (isEqualIgnoringOrder(actual, expected) === false) {
+                    fail(actual, expected, message, "equalIgnoringOrder", assert.equalIgnoringOrder);
+                }
+            } else {
+                fail(actual, expected, message, "equalIgnoringOrder", assert.equalIgnoringOrder);
+            }
+            return;
+        };
+
+        /**
+         * Performs a numeric equivalence within the given tolerance. If the
+         * difference between the arguments is within that tolerance, the assertion
+         * passes. Otherwise, it fails.
+         *
+         * @example // passing assertion
+         * assert.roughlyEqual(5.23456789, 5.2345947, 0.001);
+         *
+         * @param {Number} actual The actual value
+         * @param {Number} expected The expected value
+         * @param {Number} tolerance The tolerance for the difference between the two
+         * @throws ArgumentsError
+         * @throws AssertionError
+         */
+        assert.roughlyEqual = function(actual, expected, tolerance, message) {
+            if (typeof(actual) !== "number" || typeof(expected) !== "number" || typeof(tolerance) !== "number") {
+                fail("Invalid expected argument to roughlyEquals.");
+            } else if (Math.abs(expected - actual) >= tolerance) {
+                fail(actual, expected, message, "roughlyEquals", assert.roughlyEquals);
+            }
+            return;
+        };
+
+        /**
+         * Check the actual result to see that every property that exists in the expected
+         * object also exists in the actual object and that it has the same value. If the
+         * expected object is a string, it names the property that should exist without
+         * giving the value. If the expected object is an array, each item in the expected
+         * array should exist in the actual array. If expected is an object, then the actual
+         * object must have all properties that the expected object has and with the same
+         * value. The actual object may have more properties that do not exist in
+         * expected, but this function
+         * is used to test for only the properties that the unit test cares about.
+         *
+         * @example // passing assertion
+         * assert.contains({a: 2, b: 3}, "b");
+         *
+         * @param {Object} actual The actual value to test which may be an array or an object
+         * @param {*} expected The name of the property that is expected to be within the object in the actual parameter
+         * @param {string} message message to print when the assertion fails
+         * @throws ArgumentsError
+         * @throws AssertionError
+         */
+        assert.contains = function(actual, expected, message) {
+            if (isArray(actual)) {
+                if (typeof(expected) === "undefined") {
+                    fail("Invalid expected argument to contains.");
+                }
+                if (typeof(expected) === "object") {
+                    fail(actual, expected, message + " Expected is object and actual is array.", "contains", assert.contains);
+                } else if (isArray(expected)) {
+                    for (var i = 0; i < expected.length; i++) {
+                        if (actual.indexOf(expected[i]) < 0) {
+                            fail(actual, expected, message + " Actual array does not contain array index " + i + " of expected.", "contains", assert.contains);
+                        }
+                    }
+                } else {
+                    // primitive type -- check to see if it is in the actual array
+                    if (actual.indexOf(expected) < 0) {
+                        fail(actual, expected, message + " Expected value " + expected + " is not contained in the array in actual.", "contains", assert.contains);
+                    }
+                }
+            } else if (typeof(actual) === "object") {
+                if (typeof(expected) === "object") {
+                    for (var p in expected) {
+                        if (p && expected.hasOwnProperty(p)) {
+                            if (typeof(actual[p]) === 'undefined') {
+                                // "actual does not contain expected properties";
+                                fail(actual[p], expected[p], message + " Expected contains property " + p + " and actual does not.", "contains", assert.contains);
+                            } else if (typeof(expected[p]) === 'object') {
+                                if (!_deepEqual(actual[p], expected[p])) {
+                                    fail(actual, expected, message, "contains", assert.notDeepEqual);
+                                }
+                            } else {
+                                if (actual[p] != expected[p]) {
+                                    fail(actual, expected, message, "contains", assert.notDeepEqual);
+                                }
+                            }
+                        }
+                    }
+                } else if (isArray(expected)) {
+                    fail(actual, expected, message + " Expected is array and actual is object.", "contains", assert.contains);
+                } else if (typeof(expected) === "string") {
+                    if (typeof(actual[p]) === "undefined") {
+                        fail(actual[p], expected[p], message + " Expected is looking for property " + expected + " and actual does not contain it.", "contains", assert.contains);
+                    }
+                } else {
+                    fail("Invalid expected argument to contains.");
+                }
+            } else {
+                fail("Invalid expected argument to contains.");
+            }
+            return;
+        };
+    })(assert);
+
+    (function(exports){
+        var totalCaseNum = 0, assertionNum = 0;
+        var failNum = 0, successNum = 0;
+        var endTime = 0;
+        var startTime = new Date().getTime();
+
+        function getFailureDetails(assertion) {
+            if (assertion.error && assertion.error.name === "AssertionError") {
+                return "Expected that actual " + assertion.error.operator + " [[" + assertion.error.expected + "]] , but got [[" + assertion.error.actual + "]] instead.";
+            } else if (assertion.message) {
+                return assertion.message;
+            }
+            return "Unknown reason.";
+        }
+        
+        exports.run = function (modules) {
+            exports.runModules(modules, {
+                moduleStart: function (name) {
+                    console.log("moduleStart");
+                },
+                testDone: function (name, assertions) {
+                    totalCaseNum++;
+                    assertionNum = assertionNum + assertions.length;
+                    for (var i=0; i < assertions.length; i++) {
+                        var a = assertions[i];
+                        if (a.failed()) {
+                            failNum++;
+                            //console.log("[" + name + "] assertions.failures() " + assertions.failures());
+                            console.log("[" + name + "] assertion failed: " + getFailureDetails(a));
+                        } else {
+                            successNum++;
+                            //console.log("[" + name + "] assertions.passed() " + assertions.passed());
+                            //console.log("[" + name + "] assertion is passed");
+                        }
+                    }
+                },
+                done: function (assertions) {
+                    console.log("done");
+                }
+            });
+        };
+
+        exports.options = function(opt){
+            var optionalCallback = function(name) {
+                opt[name] = opt[name] || function() {};
+            };
+            optionalCallback('moduleStart');
+            optionalCallback('moduleDone');
+            return opt;
+        };
+
+        exports.assertion = function(obj) {
+            return {
+                method: obj.method || '',
+                message: obj.message || (obj.error && obj.error.message) || '',
+                error: obj.error,
+                passed: function() {
+                    return !this.error;
+                },
+                failed: function() {
+                    return Boolean(this.error);
+                }
+            }
+        };
+
+        /**
+        * Creates an assertion list object representing a group of assertions.
+        * Accepts an array of assertion objects.
+        *
+        * @param {Array} arr
+        * @param {Number} duration
+        * @api public
+        */
+
+        exports.assertionList = function (arr) {
+            var that = arr || [];
+            that.failures = function () {
+                var failures = 0;
+                for (var i = 0; i < this.length; i += 1) {
+                    if (this[i].failed()) {
+                        failures += 1;
+                    }
+                }
+                return failures;
+            };
+            that.passed = function () {
+                return that.length - that.failures();
+            };
+
+            return that;
+        };
+
+        var assertWrapper = function(callback) {
+            return function(new_method, assert_method, arity){
+                return function() {
+                    var message = arguments[arity -1];
+                    var a = exports.assertion({method: new_method, message: message});
+                    try {
+                       assert[assert_method].apply(null, arguments);
+                    } catch (e) {
+                        //console.log('[assertWrapper] ' + e);
+                        a.error = e;
+                    }
+                    callback(a);
+                };
+            };
+        };
+
+        exports.test = function(name, options, callback) {
+            var expecting;
+            var a_list = [];
+
+            var wrapAssert = assertWrapper(function (a) {
+                a_list.push(a);
+            });
+
+            var test = {
+                done: function (err) {
+                    if (expecting !== undefined && expecting !== a_list.length) {
+                        var e = new Error(
+                            'Expected ' + expecting + ' assertions, ' +
+                            a_list.length + ' ran'
+                        );
+                        var a1 = exports.assertion({method: 'expect', error: e});
+                            a_list.push(a1);
+                        }
+
+                    var assertion_list = exports.assertionList(a_list);
+
+                    options.testDone(name, assertion_list);
+                    callback(null, a_list);
+                },
+                ok: wrapAssert('ok', 'ok', 2),
+                same: wrapAssert('same', 'deepEqual', 3),
+                equals: wrapAssert('equals', 'equal', 3),
+                expect: function(num) {
+                    expecting = num;
+                }
+            }
+            // add all functions from the assert module
+            for (var k in assert) {
+                if (assert.hasOwnProperty(k)) {
+                    test[k] = wrapAssert(k, k, assert[k].length);
+                }
+            }
+
+            return test;
+        };
+
+        exports.runSuite = function (name, fn, opt, callback) {
+            var prop = fn;
+            var options = exports.options(opt);
+
+            for (var prop in fn) {
+                if (fn.hasOwnProperty(prop)) {
+                    if (typeof fn[prop] === 'function') {
+                        var test = exports.test(prop, options, callback);
+                        try {
+                            fn[prop](test);
+                        } catch(e) {
+                            //console.log("[exports.runSuite]" + e);
+                            test.done(e);
+                        }
+                    }
+                }
+            }
+        };
+        
+        exports.runModule = function(suite, options) {
+            exports.runSuite(null, suite, options, function(err, a_list) {
+                options.moduleDone();
+            });
+        };
+
+        exports.runModules = function(modules, opt) {
+            var options = exports.options(opt);
+            for(var testSuite in modules) {
+                if (modules.hasOwnProperty(testSuite)) {
+                    exports.runModule(modules[testSuite], options);
+                }
+            }
+        };
+        
+        exports.finish = function() {
+            endTime = new Date().getTime();
+            console.log("===========================================================================================");
+            console.log("[Result] A total of " + totalCaseNum + " tests were performed.")
+            console.log("[Result] " + successNum + " assertions of " + assertionNum + " passed, " + failNum + " failed");
+            console.log("[Result] Test completed in " + (endTime - startTime)/1000 + " seconds");
+            console.log("===========================================================================================");
+            console.log("                                                                                           ");
+        }
+
+    })(reporter);
+
+    nodeunit.reporter = reporter;
+    nodeunit.run = reporter.run;
+    nodeunit.start = reporter.start;
+    nodeunit.finish = reporter.finish;
+
+return nodeunit;
+
+})();

--- a/test/nodeunit/nodeunit.css
+++ b/test/nodeunit/nodeunit.css
@@ -1,0 +1,70 @@
+/*!
+ * Styles taken from qunit.css
+ */
+
+h1#nodeunit-header, h1.nodeunit-header {
+    padding: 15px;
+    font-size: large;
+    background-color: #06b;
+    color: white;
+    font-family: 'trebuchet ms', verdana, arial;
+    margin: 0;
+}
+
+h1#nodeunit-header a {
+    color: white;
+}
+
+h2#nodeunit-banner {
+    height: 2em;
+    border-bottom: 1px solid white;
+    background-color: #eee;
+    margin: 0;
+    font-family: 'trebuchet ms', verdana, arial;
+}
+h2#nodeunit-banner.pass {
+    background-color: green;
+}
+h2#nodeunit-banner.fail {
+    background-color: red;
+}
+
+h2#nodeunit-userAgent, h2.nodeunit-userAgent {
+    padding: 10px;
+    background-color: #eee;
+    color: black;
+    margin: 0;
+    font-size: small;
+    font-weight: normal;
+    font-family: 'trebuchet ms', verdana, arial;
+    font-size: 10pt;
+}
+
+div#nodeunit-testrunner-toolbar {
+    background: #eee;
+    border-top: 1px solid black;
+    padding: 10px;
+    font-family: 'trebuchet ms', verdana, arial;
+    margin: 0;
+    font-size: 10pt;
+}
+
+ol#nodeunit-tests {
+    font-family: 'trebuchet ms', verdana, arial;
+    font-size: 10pt;
+}
+ol#nodeunit-tests li strong {
+    cursor:pointer;
+}
+ol#nodeunit-tests .pass {
+    color: green;
+} 
+ol#nodeunit-tests .fail {
+    color: red;
+} 
+
+p#nodeunit-testresult {
+    margin-left: 1em;
+    font-size: 10pt;
+    font-family: 'trebuchet ms', verdana, arial;
+}

--- a/test/nodeunit/nodeunit.js
+++ b/test/nodeunit/nodeunit.js
@@ -1,0 +1,2290 @@
+/*!
+ * Nodeunit
+ * https://github.com/caolan/nodeunit
+ * Copyright (c) 2010 Caolan McMahon
+ * MIT Licensed
+ *
+ * json2.js
+ * http://www.JSON.org/json2.js
+ * Public Domain.
+ * NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+ */
+nodeunit = (function(){
+/*
+    http://www.JSON.org/json2.js
+    2010-11-17
+
+    Public Domain.
+
+    NO WARRANTY EXPRESSED OR IMPLIED. USE AT YOUR OWN RISK.
+
+    See http://www.JSON.org/js.html
+
+
+    This code should be minified before deployment.
+    See http://javascript.crockford.com/jsmin.html
+
+    USE YOUR OWN COPY. IT IS EXTREMELY UNWISE TO LOAD CODE FROM SERVERS YOU DO
+    NOT CONTROL.
+
+
+    This file creates a global JSON object containing two methods: stringify
+    and parse.
+
+        JSON.stringify(value, replacer, space)
+            value       any JavaScript value, usually an object or array.
+
+            replacer    an optional parameter that determines how object
+                        values are stringified for objects. It can be a
+                        function or an array of strings.
+
+            space       an optional parameter that specifies the indentation
+                        of nested structures. If it is omitted, the text will
+                        be packed without extra whitespace. If it is a number,
+                        it will specify the number of spaces to indent at each
+                        level. If it is a string (such as '\t' or '&nbsp;'),
+                        it contains the characters used to indent at each level.
+
+            This method produces a JSON text from a JavaScript value.
+
+            When an object value is found, if the object contains a toJSON
+            method, its toJSON method will be called and the result will be
+            stringified. A toJSON method does not serialize: it returns the
+            value represented by the name/value pair that should be serialized,
+            or undefined if nothing should be serialized. The toJSON method
+            will be passed the key associated with the value, and this will be
+            bound to the value
+
+            For example, this would serialize Dates as ISO strings.
+
+                Date.prototype.toJSON = function (key) {
+                    function f(n) {
+                        // Format integers to have at least two digits.
+                        return n < 10 ? '0' + n : n;
+                    }
+
+                    return this.getUTCFullYear()   + '-' +
+                         f(this.getUTCMonth() + 1) + '-' +
+                         f(this.getUTCDate())      + 'T' +
+                         f(this.getUTCHours())     + ':' +
+                         f(this.getUTCMinutes())   + ':' +
+                         f(this.getUTCSeconds())   + 'Z';
+                };
+
+            You can provide an optional replacer method. It will be passed the
+            key and value of each member, with this bound to the containing
+            object. The value that is returned from your method will be
+            serialized. If your method returns undefined, then the member will
+            be excluded from the serialization.
+
+            If the replacer parameter is an array of strings, then it will be
+            used to select the members to be serialized. It filters the results
+            such that only members with keys listed in the replacer array are
+            stringified.
+
+            Values that do not have JSON representations, such as undefined or
+            functions, will not be serialized. Such values in objects will be
+            dropped; in arrays they will be replaced with null. You can use
+            a replacer function to replace those with JSON values.
+            JSON.stringify(undefined) returns undefined.
+
+            The optional space parameter produces a stringification of the
+            value that is filled with line breaks and indentation to make it
+            easier to read.
+
+            If the space parameter is a non-empty string, then that string will
+            be used for indentation. If the space parameter is a number, then
+            the indentation will be that many spaces.
+
+            Example:
+
+            text = JSON.stringify(['e', {pluribus: 'unum'}]);
+            // text is '["e",{"pluribus":"unum"}]'
+
+
+            text = JSON.stringify(['e', {pluribus: 'unum'}], null, '\t');
+            // text is '[\n\t"e",\n\t{\n\t\t"pluribus": "unum"\n\t}\n]'
+
+            text = JSON.stringify([new Date()], function (key, value) {
+                return this[key] instanceof Date ?
+                    'Date(' + this[key] + ')' : value;
+            });
+            // text is '["Date(---current time---)"]'
+
+
+        JSON.parse(text, reviver)
+            This method parses a JSON text to produce an object or array.
+            It can throw a SyntaxError exception.
+
+            The optional reviver parameter is a function that can filter and
+            transform the results. It receives each of the keys and values,
+            and its return value is used instead of the original value.
+            If it returns what it received, then the structure is not modified.
+            If it returns undefined then the member is deleted.
+
+            Example:
+
+            // Parse the text. Values that look like ISO date strings will
+            // be converted to Date objects.
+
+            myData = JSON.parse(text, function (key, value) {
+                var a;
+                if (typeof value === 'string') {
+                    a =
+/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*)?)Z$/.exec(value);
+                    if (a) {
+                        return new Date(Date.UTC(+a[1], +a[2] - 1, +a[3], +a[4],
+                            +a[5], +a[6]));
+                    }
+                }
+                return value;
+            });
+
+            myData = JSON.parse('["Date(09/09/2001)"]', function (key, value) {
+                var d;
+                if (typeof value === 'string' &&
+                        value.slice(0, 5) === 'Date(' &&
+                        value.slice(-1) === ')') {
+                    d = new Date(value.slice(5, -1));
+                    if (d) {
+                        return d;
+                    }
+                }
+                return value;
+            });
+
+
+    This is a reference implementation. You are free to copy, modify, or
+    redistribute.
+*/
+
+/*jslint evil: true, strict: false, regexp: false */
+
+/*members "", "\b", "\t", "\n", "\f", "\r", "\"", JSON, "\\", apply,
+    call, charCodeAt, getUTCDate, getUTCFullYear, getUTCHours,
+    getUTCMinutes, getUTCMonth, getUTCSeconds, hasOwnProperty, join,
+    lastIndex, length, parse, prototype, push, replace, slice, stringify,
+    test, toJSON, toString, valueOf
+*/
+
+
+// Create a JSON object only if one does not already exist. We create the
+// methods in a closure to avoid creating global variables.
+
+var JSON = {};
+
+(function () {
+    "use strict";
+
+    function f(n) {
+        // Format integers to have at least two digits.
+        return n < 10 ? '0' + n : n;
+    }
+
+    if (typeof Date.prototype.toJSON !== 'function') {
+
+        Date.prototype.toJSON = function (key) {
+
+            return isFinite(this.valueOf()) ?
+                   this.getUTCFullYear()   + '-' +
+                 f(this.getUTCMonth() + 1) + '-' +
+                 f(this.getUTCDate())      + 'T' +
+                 f(this.getUTCHours())     + ':' +
+                 f(this.getUTCMinutes())   + ':' +
+                 f(this.getUTCSeconds())   + 'Z' : null;
+        };
+
+        String.prototype.toJSON =
+        Number.prototype.toJSON =
+        Boolean.prototype.toJSON = function (key) {
+            return this.valueOf();
+        };
+    }
+
+    var cx = /[\u0000\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g,
+        escapable = /[\\\"\x00-\x1f\x7f-\x9f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g,
+        gap,
+        indent,
+        meta = {    // table of character substitutions
+            '\b': '\\b',
+            '\t': '\\t',
+            '\n': '\\n',
+            '\f': '\\f',
+            '\r': '\\r',
+            '"' : '\\"',
+            '\\': '\\\\'
+        },
+        rep;
+
+
+    function quote(string) {
+
+// If the string contains no control characters, no quote characters, and no
+// backslash characters, then we can safely slap some quotes around it.
+// Otherwise we must also replace the offending characters with safe escape
+// sequences.
+
+        escapable.lastIndex = 0;
+        return escapable.test(string) ?
+            '"' + string.replace(escapable, function (a) {
+                var c = meta[a];
+                return typeof c === 'string' ? c :
+                    '\\u' + ('0000' + a.charCodeAt(0).toString(16)).slice(-4);
+            }) + '"' :
+            '"' + string + '"';
+    }
+
+
+    function str(key, holder) {
+
+// Produce a string from holder[key].
+
+        var i,          // The loop counter.
+            k,          // The member key.
+            v,          // The member value.
+            length,
+            mind = gap,
+            partial,
+            value = holder[key];
+
+// If the value has a toJSON method, call it to obtain a replacement value.
+
+        if (value && typeof value === 'object' &&
+                typeof value.toJSON === 'function') {
+            value = value.toJSON(key);
+        }
+
+// If we were called with a replacer function, then call the replacer to
+// obtain a replacement value.
+
+        if (typeof rep === 'function') {
+            value = rep.call(holder, key, value);
+        }
+
+// What happens next depends on the value's type.
+
+        switch (typeof value) {
+        case 'string':
+            return quote(value);
+
+        case 'number':
+
+// JSON numbers must be finite. Encode non-finite numbers as null.
+
+            return isFinite(value) ? String(value) : 'null';
+
+        case 'boolean':
+        case 'null':
+
+// If the value is a boolean or null, convert it to a string. Note:
+// typeof null does not produce 'null'. The case is included here in
+// the remote chance that this gets fixed someday.
+
+            return String(value);
+
+// If the type is 'object', we might be dealing with an object or an array or
+// null.
+
+        case 'object':
+
+// Due to a specification blunder in ECMAScript, typeof null is 'object',
+// so watch out for that case.
+
+            if (!value) {
+                return 'null';
+            }
+
+// Make an array to hold the partial results of stringifying this object value.
+
+            gap += indent;
+            partial = [];
+
+// Is the value an array?
+
+            if (Object.prototype.toString.apply(value) === '[object Array]') {
+
+// The value is an array. Stringify every element. Use null as a placeholder
+// for non-JSON values.
+
+                length = value.length;
+                for (i = 0; i < length; i += 1) {
+                    partial[i] = str(i, value) || 'null';
+                }
+
+// Join all of the elements together, separated with commas, and wrap them in
+// brackets.
+
+                v = partial.length === 0 ? '[]' :
+                    gap ? '[\n' + gap +
+                            partial.join(',\n' + gap) + '\n' +
+                                mind + ']' :
+                          '[' + partial.join(',') + ']';
+                gap = mind;
+                return v;
+            }
+
+// If the replacer is an array, use it to select the members to be stringified.
+
+            if (rep && typeof rep === 'object') {
+                length = rep.length;
+                for (i = 0; i < length; i += 1) {
+                    k = rep[i];
+                    if (typeof k === 'string') {
+                        v = str(k, value);
+                        if (v) {
+                            partial.push(quote(k) + (gap ? ': ' : ':') + v);
+                        }
+                    }
+                }
+            } else {
+
+// Otherwise, iterate through all of the keys in the object.
+
+                for (k in value) {
+                    if (Object.hasOwnProperty.call(value, k)) {
+                        v = str(k, value);
+                        if (v) {
+                            partial.push(quote(k) + (gap ? ': ' : ':') + v);
+                        }
+                    }
+                }
+            }
+
+// Join all of the member texts together, separated with commas,
+// and wrap them in braces.
+
+            v = partial.length === 0 ? '{}' :
+                gap ? '{\n' + gap + partial.join(',\n' + gap) + '\n' +
+                        mind + '}' : '{' + partial.join(',') + '}';
+            gap = mind;
+            return v;
+        }
+    }
+
+// If the JSON object does not yet have a stringify method, give it one.
+
+    if (typeof JSON.stringify !== 'function') {
+        JSON.stringify = function (value, replacer, space) {
+
+// The stringify method takes a value and an optional replacer, and an optional
+// space parameter, and returns a JSON text. The replacer can be a function
+// that can replace values, or an array of strings that will select the keys.
+// A default replacer method can be provided. Use of the space parameter can
+// produce text that is more easily readable.
+
+            var i;
+            gap = '';
+            indent = '';
+
+// If the space parameter is a number, make an indent string containing that
+// many spaces.
+
+            if (typeof space === 'number') {
+                for (i = 0; i < space; i += 1) {
+                    indent += ' ';
+                }
+
+// If the space parameter is a string, it will be used as the indent string.
+
+            } else if (typeof space === 'string') {
+                indent = space;
+            }
+
+// If there is a replacer, it must be a function or an array.
+// Otherwise, throw an error.
+
+            rep = replacer;
+            if (replacer && typeof replacer !== 'function' &&
+                    (typeof replacer !== 'object' ||
+                     typeof replacer.length !== 'number')) {
+                throw new Error('JSON.stringify');
+            }
+
+// Make a fake root object containing our value under the key of ''.
+// Return the result of stringifying the value.
+
+            return str('', {'': value});
+        };
+    }
+
+
+// If the JSON object does not yet have a parse method, give it one.
+
+    if (typeof JSON.parse !== 'function') {
+        JSON.parse = function (text, reviver) {
+
+// The parse method takes a text and an optional reviver function, and returns
+// a JavaScript value if the text is a valid JSON text.
+
+            var j;
+
+            function walk(holder, key) {
+
+// The walk method is used to recursively walk the resulting structure so
+// that modifications can be made.
+
+                var k, v, value = holder[key];
+                if (value && typeof value === 'object') {
+                    for (k in value) {
+                        if (Object.hasOwnProperty.call(value, k)) {
+                            v = walk(value, k);
+                            if (v !== undefined) {
+                                value[k] = v;
+                            } else {
+                                delete value[k];
+                            }
+                        }
+                    }
+                }
+                return reviver.call(holder, key, value);
+            }
+
+
+// Parsing happens in four stages. In the first stage, we replace certain
+// Unicode characters with escape sequences. JavaScript handles many characters
+// incorrectly, either silently deleting them, or treating them as line endings.
+
+            text = String(text);
+            cx.lastIndex = 0;
+            if (cx.test(text)) {
+                text = text.replace(cx, function (a) {
+                    return '\\u' +
+                        ('0000' + a.charCodeAt(0).toString(16)).slice(-4);
+                });
+            }
+
+// In the second stage, we run the text against regular expressions that look
+// for non-JSON patterns. We are especially concerned with '()' and 'new'
+// because they can cause invocation, and '=' because it can cause mutation.
+// But just to be safe, we want to reject all unexpected forms.
+
+// We split the second stage into 4 regexp operations in order to work around
+// crippling inefficiencies in IE's and Safari's regexp engines. First we
+// replace the JSON backslash pairs with '@' (a non-JSON character). Second, we
+// replace all simple value tokens with ']' characters. Third, we delete all
+// open brackets that follow a colon or comma or that begin the text. Finally,
+// we look to see that the remaining characters are only whitespace or ']' or
+// ',' or ':' or '{' or '}'. If that is so, then the text is safe for eval.
+
+            if (/^[\],:{}\s]*$/
+.test(text.replace(/\\(?:["\\\/bfnrt]|u[0-9a-fA-F]{4})/g, '@')
+.replace(/"[^"\\\n\r]*"|true|false|null|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?/g, ']')
+.replace(/(?:^|:|,)(?:\s*\[)+/g, ''))) {
+
+// In the third stage we use the eval function to compile the text into a
+// JavaScript structure. The '{' operator is subject to a syntactic ambiguity
+// in JavaScript: it can begin a block or an object literal. We wrap the text
+// in parens to eliminate the ambiguity.
+
+                j = eval('(' + text + ')');
+
+// In the optional fourth stage, we recursively walk the new structure, passing
+// each name/value pair to a reviver function for possible transformation.
+
+                return typeof reviver === 'function' ?
+                    walk({'': j}, '') : j;
+            }
+
+// If the text is not JSON parseable, then a SyntaxError is thrown.
+
+            throw new SyntaxError('JSON.parse');
+        };
+    }
+}());
+var assert = this.assert = {};
+var types = {};
+var core = {};
+var nodeunit = {};
+var reporter = {};
+/*global setTimeout: false, console: false */
+(function () {
+
+    var async = {};
+
+    // global on the server, window in the browser
+    var root = this,
+        previous_async = root.async;
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = async;
+    }
+    else {
+        root.async = async;
+    }
+
+    async.noConflict = function () {
+        root.async = previous_async;
+        return async;
+    };
+
+    //// cross-browser compatiblity functions ////
+
+    var _forEach = function (arr, iterator) {
+        if (arr.forEach) {
+            return arr.forEach(iterator);
+        }
+        for (var i = 0; i < arr.length; i += 1) {
+            iterator(arr[i], i, arr);
+        }
+    };
+
+    var _map = function (arr, iterator) {
+        if (arr.map) {
+            return arr.map(iterator);
+        }
+        var results = [];
+        _forEach(arr, function (x, i, a) {
+            results.push(iterator(x, i, a));
+        });
+        return results;
+    };
+
+    var _reduce = function (arr, iterator, memo) {
+        if (arr.reduce) {
+            return arr.reduce(iterator, memo);
+        }
+        _forEach(arr, function (x, i, a) {
+            memo = iterator(memo, x, i, a);
+        });
+        return memo;
+    };
+
+    var _keys = function (obj) {
+        if (Object.keys) {
+            return Object.keys(obj);
+        }
+        var keys = [];
+        for (var k in obj) {
+            if (obj.hasOwnProperty(k)) {
+                keys.push(k);
+            }
+        }
+        return keys;
+    };
+
+    var _indexOf = function (arr, item) {
+        if (arr.indexOf) {
+            return arr.indexOf(item);
+        }
+        for (var i = 0; i < arr.length; i += 1) {
+            if (arr[i] === item) {
+                return i;
+            }
+        }
+        return -1;
+    };
+
+    //// exported async module functions ////
+
+    //// nextTick implementation with browser-compatible fallback ////
+    if (typeof setImmediate === 'function') {
+        async.nextTick = function (fn) {
+            setImmediate(fn);
+        };
+    }
+    else if (typeof process !== 'undefined' && process.nextTick) {
+        async.nextTick = process.nextTick;
+    }
+    else {
+        async.nextTick = function (fn) {
+            setTimeout(fn, 0);
+        };
+    }
+
+    async.forEach = function (arr, iterator, callback) {
+        if (!arr.length) {
+            return callback();
+        }
+        var completed = 0;
+        _forEach(arr, function (x) {
+            iterator(x, function (err) {
+                if (err) {
+                    callback(err);
+                    callback = function () {};
+                }
+                else {
+                    completed += 1;
+                    if (completed === arr.length) {
+                        callback();
+                    }
+                }
+            });
+        });
+    };
+
+    async.forEachSeries = function (arr, iterator, callback) {
+        if (!arr.length) {
+            return callback();
+        }
+        var completed = 0;
+        var iterate = function () {
+            iterator(arr[completed], function (err) {
+                if (err) {
+                    callback(err);
+                    callback = function () {};
+                }
+                else {
+                    completed += 1;
+                    if (completed === arr.length) {
+                        callback();
+                    }
+                    else {
+                        iterate();
+                    }
+                }
+            });
+        };
+        iterate();
+    };
+
+
+    var doParallel = function (fn) {
+        return function () {
+            var args = Array.prototype.slice.call(arguments);
+            return fn.apply(null, [async.forEach].concat(args));
+        };
+    };
+    var doSeries = function (fn) {
+        return function () {
+            var args = Array.prototype.slice.call(arguments);
+            return fn.apply(null, [async.forEachSeries].concat(args));
+        };
+    };
+
+
+    var _asyncMap = function (eachfn, arr, iterator, callback) {
+        var results = [];
+        arr = _map(arr, function (x, i) {
+            return {index: i, value: x};
+        });
+        eachfn(arr, function (x, callback) {
+            iterator(x.value, function (err, v) {
+                results[x.index] = v;
+                callback(err);
+            });
+        }, function (err) {
+            callback(err, results);
+        });
+    };
+    async.map = doParallel(_asyncMap);
+    async.mapSeries = doSeries(_asyncMap);
+
+
+    // reduce only has a series version, as doing reduce in parallel won't
+    // work in many situations.
+    async.reduce = function (arr, memo, iterator, callback) {
+        async.forEachSeries(arr, function (x, callback) {
+            iterator(memo, x, function (err, v) {
+                memo = v;
+                callback(err);
+            });
+        }, function (err) {
+            callback(err, memo);
+        });
+    };
+    // inject alias
+    async.inject = async.reduce;
+    // foldl alias
+    async.foldl = async.reduce;
+
+    async.reduceRight = function (arr, memo, iterator, callback) {
+        var reversed = _map(arr, function (x) {
+            return x;
+        }).reverse();
+        async.reduce(reversed, memo, iterator, callback);
+    };
+    // foldr alias
+    async.foldr = async.reduceRight;
+
+    var _filter = function (eachfn, arr, iterator, callback) {
+        var results = [];
+        arr = _map(arr, function (x, i) {
+            return {index: i, value: x};
+        });
+        eachfn(arr, function (x, callback) {
+            iterator(x.value, function (v) {
+                if (v) {
+                    results.push(x);
+                }
+                callback();
+            });
+        }, function (err) {
+            callback(_map(results.sort(function (a, b) {
+                return a.index - b.index;
+            }), function (x) {
+                return x.value;
+            }));
+        });
+    };
+    async.filter = doParallel(_filter);
+    async.filterSeries = doSeries(_filter);
+    // select alias
+    async.select = async.filter;
+    async.selectSeries = async.filterSeries;
+
+    var _reject = function (eachfn, arr, iterator, callback) {
+        var results = [];
+        arr = _map(arr, function (x, i) {
+            return {index: i, value: x};
+        });
+        eachfn(arr, function (x, callback) {
+            iterator(x.value, function (v) {
+                if (!v) {
+                    results.push(x);
+                }
+                callback();
+            });
+        }, function (err) {
+            callback(_map(results.sort(function (a, b) {
+                return a.index - b.index;
+            }), function (x) {
+                return x.value;
+            }));
+        });
+    };
+    async.reject = doParallel(_reject);
+    async.rejectSeries = doSeries(_reject);
+
+    var _detect = function (eachfn, arr, iterator, main_callback) {
+        eachfn(arr, function (x, callback) {
+            iterator(x, function (result) {
+                if (result) {
+                    main_callback(x);
+                }
+                else {
+                    callback();
+                }
+            });
+        }, function (err) {
+            main_callback();
+        });
+    };
+    async.detect = doParallel(_detect);
+    async.detectSeries = doSeries(_detect);
+
+    async.some = function (arr, iterator, main_callback) {
+        async.forEach(arr, function (x, callback) {
+            iterator(x, function (v) {
+                if (v) {
+                    main_callback(true);
+                    main_callback = function () {};
+                }
+                callback();
+            });
+        }, function (err) {
+            main_callback(false);
+        });
+    };
+    // any alias
+    async.any = async.some;
+
+    async.every = function (arr, iterator, main_callback) {
+        async.forEach(arr, function (x, callback) {
+            iterator(x, function (v) {
+                if (!v) {
+                    main_callback(false);
+                    main_callback = function () {};
+                }
+                callback();
+            });
+        }, function (err) {
+            main_callback(true);
+        });
+    };
+    // all alias
+    async.all = async.every;
+
+    async.sortBy = function (arr, iterator, callback) {
+        async.map(arr, function (x, callback) {
+            iterator(x, function (err, criteria) {
+                if (err) {
+                    callback(err);
+                }
+                else {
+                    callback(null, {value: x, criteria: criteria});
+                }
+            });
+        }, function (err, results) {
+            if (err) {
+                return callback(err);
+            }
+            else {
+                var fn = function (left, right) {
+                    var a = left.criteria, b = right.criteria;
+                    return a < b ? -1 : a > b ? 1 : 0;
+                };
+                callback(null, _map(results.sort(fn), function (x) {
+                    return x.value;
+                }));
+            }
+        });
+    };
+
+    async.auto = function (tasks, callback) {
+        callback = callback || function () {};
+        var keys = _keys(tasks);
+        if (!keys.length) {
+            return callback(null);
+        }
+
+        var completed = [];
+
+        var listeners = [];
+        var addListener = function (fn) {
+            listeners.unshift(fn);
+        };
+        var removeListener = function (fn) {
+            for (var i = 0; i < listeners.length; i += 1) {
+                if (listeners[i] === fn) {
+                    listeners.splice(i, 1);
+                    return;
+                }
+            }
+        };
+        var taskComplete = function () {
+            _forEach(listeners, function (fn) {
+                fn();
+            });
+        };
+
+        addListener(function () {
+            if (completed.length === keys.length) {
+                callback(null);
+            }
+        });
+
+        _forEach(keys, function (k) {
+            var task = (tasks[k] instanceof Function) ? [tasks[k]]: tasks[k];
+            var taskCallback = function (err) {
+                if (err) {
+                    callback(err);
+                    // stop subsequent errors hitting callback multiple times
+                    callback = function () {};
+                }
+                else {
+                    completed.push(k);
+                    taskComplete();
+                }
+            };
+            var requires = task.slice(0, Math.abs(task.length - 1)) || [];
+            var ready = function () {
+                return _reduce(requires, function (a, x) {
+                    return (a && _indexOf(completed, x) !== -1);
+                }, true);
+            };
+            if (ready()) {
+                task[task.length - 1](taskCallback);
+            }
+            else {
+                var listener = function () {
+                    if (ready()) {
+                        removeListener(listener);
+                        task[task.length - 1](taskCallback);
+                    }
+                };
+                addListener(listener);
+            }
+        });
+    };
+
+    async.waterfall = function (tasks, callback) {
+        if (!tasks.length) {
+            return callback();
+        }
+        callback = callback || function () {};
+        var wrapIterator = function (iterator) {
+            return function (err) {
+                if (err) {
+                    callback(err);
+                    callback = function () {};
+                }
+                else {
+                    var args = Array.prototype.slice.call(arguments, 1);
+                    var next = iterator.next();
+                    if (next) {
+                        args.push(wrapIterator(next));
+                    }
+                    else {
+                        args.push(callback);
+                    }
+                    async.nextTick(function () {
+                        iterator.apply(null, args);
+                    });
+                }
+            };
+        };
+        wrapIterator(async.iterator(tasks))();
+    };
+
+    async.parallel = function (tasks, callback) {
+        callback = callback || function () {};
+        if (tasks.constructor === Array) {
+            async.map(tasks, function (fn, callback) {
+                if (fn) {
+                    fn(function (err) {
+                        var args = Array.prototype.slice.call(arguments, 1);
+                        if (args.length <= 1) {
+                            args = args[0];
+                        }
+                        callback.call(null, err, args || null);
+                    });
+                }
+            }, callback);
+        }
+        else {
+            var results = {};
+            async.forEach(_keys(tasks), function (k, callback) {
+                tasks[k](function (err) {
+                    var args = Array.prototype.slice.call(arguments, 1);
+                    if (args.length <= 1) {
+                        args = args[0];
+                    }
+                    results[k] = args;
+                    callback(err);
+                });
+            }, function (err) {
+                callback(err, results);
+            });
+        }
+    };
+
+    async.series = function (tasks, callback) {
+        callback = callback || function () {};
+        if (tasks.constructor === Array) {
+            async.mapSeries(tasks, function (fn, callback) {
+                if (fn) {
+                    fn(function (err) {
+                        var args = Array.prototype.slice.call(arguments, 1);
+                        if (args.length <= 1) {
+                            args = args[0];
+                        }
+                        callback.call(null, err, args || null);
+                    });
+                }
+            }, callback);
+        }
+        else {
+            var results = {};
+            async.forEachSeries(_keys(tasks), function (k, callback) {
+                tasks[k](function (err) {
+                    var args = Array.prototype.slice.call(arguments, 1);
+                    if (args.length <= 1) {
+                        args = args[0];
+                    }
+                    results[k] = args;
+                    callback(err);
+                });
+            }, function (err) {
+                callback(err, results);
+            });
+        }
+    };
+
+    async.iterator = function (tasks) {
+        var makeCallback = function (index) {
+            var fn = function () {
+                if (tasks.length) {
+                    tasks[index].apply(null, arguments);
+                }
+                return fn.next();
+            };
+            fn.next = function () {
+                return (index < tasks.length - 1) ? makeCallback(index + 1): null;
+            };
+            return fn;
+        };
+        return makeCallback(0);
+    };
+
+    async.apply = function (fn) {
+        var args = Array.prototype.slice.call(arguments, 1);
+        return function () {
+            return fn.apply(
+                null, args.concat(Array.prototype.slice.call(arguments))
+            );
+        };
+    };
+
+    var _concat = function (eachfn, arr, fn, callback) {
+        var r = [];
+        eachfn(arr, function (x, cb) {
+            fn(x, function (err, y) {
+                r = r.concat(y || []);
+                cb(err);
+            });
+        }, function (err) {
+            callback(err, r);
+        });
+    };
+    async.concat = doParallel(_concat);
+    async.concatSeries = doSeries(_concat);
+
+    async.whilst = function (test, iterator, callback) {
+        if (test()) {
+            iterator(function (err) {
+                if (err) {
+                    return callback(err);
+                }
+                async.whilst(test, iterator, callback);
+            });
+        }
+        else {
+            callback();
+        }
+    };
+
+    async.until = function (test, iterator, callback) {
+        if (!test()) {
+            iterator(function (err) {
+                if (err) {
+                    return callback(err);
+                }
+                async.until(test, iterator, callback);
+            });
+        }
+        else {
+            callback();
+        }
+    };
+
+    async.queue = function (worker, concurrency) {
+        var workers = 0;
+        var tasks = [];
+        var q = {
+            concurrency: concurrency,
+            push: function (data, callback) {
+                tasks.push({data: data, callback: callback});
+                async.nextTick(q.process);
+            },
+            process: function () {
+                if (workers < q.concurrency && tasks.length) {
+                    var task = tasks.splice(0, 1)[0];
+                    workers += 1;
+                    worker(task.data, function () {
+                        workers -= 1;
+                        if (task.callback) {
+                            task.callback.apply(task, arguments);
+                        }
+                        q.process();
+                    });
+                }
+            },
+            length: function () {
+                return tasks.length;
+            }
+        };
+        return q;
+    };
+
+    var _console_fn = function (name) {
+        return function (fn) {
+            var args = Array.prototype.slice.call(arguments, 1);
+            fn.apply(null, args.concat([function (err) {
+                var args = Array.prototype.slice.call(arguments, 1);
+                if (typeof console !== 'undefined') {
+                    if (err) {
+                        if (console.error) {
+                            console.error(err);
+                        }
+                    }
+                    else if (console[name]) {
+                        _forEach(args, function (x) {
+                            console[name](x);
+                        });
+                    }
+                }
+            }]));
+        };
+    };
+    async.log = _console_fn('log');
+    async.dir = _console_fn('dir');
+    /*async.info = _console_fn('info');
+    async.warn = _console_fn('warn');
+    async.error = _console_fn('error');*/
+
+    async.memoize = function (fn, hasher) {
+        var memo = {};
+        hasher = hasher || function (x) {
+            return x;
+        };
+        return function () {
+            var args = Array.prototype.slice.call(arguments);
+            var callback = args.pop();
+            var key = hasher.apply(null, args);
+            if (key in memo) {
+                callback.apply(null, memo[key]);
+            }
+            else {
+                fn.apply(null, args.concat([function () {
+                    memo[key] = arguments;
+                    callback.apply(null, arguments);
+                }]));
+            }
+        };
+    };
+
+}());
+(function(exports){
+/**
+ * This file is based on the node.js assert module, but with some small
+ * changes for browser-compatibility
+ * THIS FILE SHOULD BE BROWSER-COMPATIBLE JS!
+ */
+
+
+/**
+ * Added for browser compatibility
+ */
+
+var _keys = function(obj){
+    if(Object.keys) return Object.keys(obj);
+    if (typeof obj != 'object' && typeof obj != 'function') {
+        throw new TypeError('-');
+    }
+    var keys = [];
+    for(var k in obj){
+        if(obj.hasOwnProperty(k)) keys.push(k);
+    }
+    return keys;
+};
+
+
+
+// http://wiki.commonjs.org/wiki/Unit_Testing/1.0
+//
+// THIS IS NOT TESTED NOR LIKELY TO WORK OUTSIDE V8!
+//
+// Originally from narwhal.js (http://narwhaljs.org)
+// Copyright (c) 2009 Thomas Robinson <280north.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the 'Software'), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+// ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+var pSlice = Array.prototype.slice;
+
+// 1. The assert module provides functions that throw
+// AssertionError's when particular conditions are not met. The
+// assert module must conform to the following interface.
+
+var assert = exports;
+
+// 2. The AssertionError is defined in assert.
+// new assert.AssertionError({message: message, actual: actual, expected: expected})
+
+assert.AssertionError = function AssertionError (options) {
+  this.name = "AssertionError";
+  this.message = options.message;
+  this.actual = options.actual;
+  this.expected = options.expected;
+  this.operator = options.operator;
+  var stackStartFunction = options.stackStartFunction || fail;
+
+  if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, stackStartFunction);
+  }
+};
+// code from util.inherits in node
+assert.AssertionError.super_ = Error;
+
+
+// EDITED FOR BROWSER COMPATIBILITY: replaced Object.create call
+// TODO: test what effect this may have
+var ctor = function () { this.constructor = assert.AssertionError; };
+ctor.prototype = Error.prototype;
+assert.AssertionError.prototype = new ctor();
+
+
+assert.AssertionError.prototype.toString = function() {
+  if (this.message) {
+    return [this.name+":", this.message].join(' ');
+  } else {
+    return [ this.name+":"
+           , typeof this.expected !== 'undefined' ? JSON.stringify(this.expected) : 'undefined'
+           , this.operator
+           , typeof this.actual !== 'undefined' ? JSON.stringify(this.actual) : 'undefined'
+           ].join(" ");
+  }
+};
+
+// assert.AssertionError instanceof Error
+
+assert.AssertionError.__proto__ = Error.prototype;
+
+// At present only the three keys mentioned above are used and
+// understood by the spec. Implementations or sub modules can pass
+// other keys to the AssertionError's constructor - they will be
+// ignored.
+
+// 3. All of the following functions must throw an AssertionError
+// when a corresponding condition is not met, with a message that
+// may be undefined if not provided.  All assertion methods provide
+// both the actual and expected values to the assertion error for
+// display purposes.
+
+function fail(actual, expected, message, operator, stackStartFunction) {
+  throw new assert.AssertionError({
+    message: message,
+    actual: actual,
+    expected: expected,
+    operator: operator,
+    stackStartFunction: stackStartFunction
+  });
+}
+
+// EXTENSION! allows for well behaved errors defined elsewhere.
+assert.fail = fail;
+
+// 4. Pure assertion tests whether a value is truthy, as determined
+// by !!guard.
+// assert.ok(guard, message_opt);
+// This statement is equivalent to assert.equal(true, guard,
+// message_opt);. To test strictly for the value true, use
+// assert.strictEqual(true, guard, message_opt);.
+
+assert.ok = function ok(value, message) {
+  if (!!!value) fail(value, true, message, "==", assert.ok);
+};
+
+// 5. The equality assertion tests shallow, coercive equality with
+// ==.
+// assert.equal(actual, expected, message_opt);
+
+assert.equal = function equal(actual, expected, message) {
+  if (actual != expected) fail(actual, expected, message, "==", assert.equal);
+};
+
+// 6. The non-equality assertion tests for whether two objects are not equal
+// with != assert.notEqual(actual, expected, message_opt);
+
+assert.notEqual = function notEqual(actual, expected, message) {
+  if (actual == expected) {
+    fail(actual, expected, message, "!=", assert.notEqual);
+  }
+};
+
+// 7. The equivalence assertion tests a deep equality relation.
+// assert.deepEqual(actual, expected, message_opt);
+
+assert.deepEqual = function deepEqual(actual, expected, message) {
+  if (!_deepEqual(actual, expected)) {
+    fail(actual, expected, message, "deepEqual", assert.deepEqual);
+  }
+};
+
+var Buffer = null;
+if (typeof require !== 'undefined' && typeof process !== 'undefined') {
+    try {
+        Buffer = require('buffer').Buffer;
+    }
+    catch (e) {
+        // May be a CommonJS environment other than Node.js
+        Buffer = null;
+    }
+}
+
+function _deepEqual(actual, expected) {
+  // 7.1. All identical values are equivalent, as determined by ===.
+  if (actual === expected) {
+    return true;
+  // 7.2. If the expected value is a Date object, the actual value is
+  // equivalent if it is also a Date object that refers to the same time.
+  } else if (actual instanceof Date && expected instanceof Date) {
+    return actual.getTime() === expected.getTime();
+
+  // 7.2.1 If the expcted value is a RegExp object, the actual value is
+  // equivalent if it is also a RegExp object that refers to the same source and options
+  } else if (actual instanceof RegExp && expected instanceof RegExp) {
+    return actual.source === expected.source &&
+           actual.global === expected.global &&
+           actual.ignoreCase === expected.ignoreCase &&
+           actual.multiline === expected.multiline;
+
+  } else if (Buffer && actual instanceof Buffer && expected instanceof Buffer) {
+    return (function() {
+      var i, len;
+
+      for (i = 0, len = expected.length; i < len; i++) {
+        if (actual[i] !== expected[i]) {
+          return false;
+        }
+      }
+      return actual.length === expected.length;
+    })();
+  // 7.3. Other pairs that do not both pass typeof value == "object",
+  // equivalence is determined by ==.
+  } else if (typeof actual != 'object' && typeof expected != 'object') {
+    return actual == expected;
+
+  // 7.4. For all other Object pairs, including Array objects, equivalence is
+  // determined by having the same number of owned properties (as verified
+  // with Object.prototype.hasOwnProperty.call), the same set of keys
+  // (although not necessarily the same order), equivalent values for every
+  // corresponding key, and an identical "prototype" property. Note: this
+  // accounts for both named and indexed properties on Arrays.
+  } else {
+    return objEquiv(actual, expected);
+  }
+}
+
+function isUndefinedOrNull (value) {
+  return value === null || value === undefined;
+}
+
+function isArguments (object) {
+  return Object.prototype.toString.call(object) == '[object Arguments]';
+}
+
+function objEquiv (a, b) {
+  if (isUndefinedOrNull(a) || isUndefinedOrNull(b))
+    return false;
+  // an identical "prototype" property.
+  if (a.prototype !== b.prototype) return false;
+  //~~~I've managed to break Object.keys through screwy arguments passing.
+  //   Converting to array solves the problem.
+  if (isArguments(a)) {
+    if (!isArguments(b)) {
+      return false;
+    }
+    a = pSlice.call(a);
+    b = pSlice.call(b);
+    return _deepEqual(a, b);
+  }
+  try{
+    var ka = _keys(a),
+      kb = _keys(b),
+      key, i;
+  } catch (e) {//happens when one is a string literal and the other isn't
+    return false;
+  }
+  // having the same number of owned properties (keys incorporates hasOwnProperty)
+  if (ka.length != kb.length)
+    return false;
+  //the same set of keys (although not necessarily the same order),
+  ka.sort();
+  kb.sort();
+  //~~~cheap key test
+  for (i = ka.length - 1; i >= 0; i--) {
+    if (ka[i] != kb[i])
+      return false;
+  }
+  //equivalent values for every corresponding key, and
+  //~~~possibly expensive deep test
+  for (i = ka.length - 1; i >= 0; i--) {
+    key = ka[i];
+    if (!_deepEqual(a[key], b[key] ))
+       return false;
+  }
+  return true;
+}
+
+// 8. The non-equivalence assertion tests for any deep inequality.
+// assert.notDeepEqual(actual, expected, message_opt);
+
+assert.notDeepEqual = function notDeepEqual(actual, expected, message) {
+  if (_deepEqual(actual, expected)) {
+    fail(actual, expected, message, "notDeepEqual", assert.notDeepEqual);
+  }
+};
+
+// 9. The strict equality assertion tests strict equality, as determined by ===.
+// assert.strictEqual(actual, expected, message_opt);
+
+assert.strictEqual = function strictEqual(actual, expected, message) {
+  if (actual !== expected) {
+    fail(actual, expected, message, "===", assert.strictEqual);
+  }
+};
+
+// 10. The strict non-equality assertion tests for strict inequality, as determined by !==.
+// assert.notStrictEqual(actual, expected, message_opt);
+
+assert.notStrictEqual = function notStrictEqual(actual, expected, message) {
+  if (actual === expected) {
+    fail(actual, expected, message, "!==", assert.notStrictEqual);
+  }
+};
+
+function expectedException(actual, expected) {
+  if (!actual || !expected) {
+    return false;
+  }
+
+  if (expected instanceof RegExp) {
+    return expected.test(actual.message || actual);
+  } else if (actual instanceof expected) {
+    return true;
+  } else if (expected.call({}, actual) === true) {
+    return true;
+  }
+
+  return false;
+}
+
+function _throws(shouldThrow, block, expected, message) {
+  var actual;
+
+  if (typeof expected === 'string') {
+    message = expected;
+    expected = null;
+  }
+
+  try {
+    block();
+  } catch (e) {
+    actual = e;
+  }
+
+  message = (expected && expected.name ? ' (' + expected.name + ').' : '.') +
+            (message ? ' ' + message : '.');
+
+  if (shouldThrow && !actual) {
+    fail('Missing expected exception' + message);
+  }
+
+  if (!shouldThrow && expectedException(actual, expected)) {
+    fail('Got unwanted exception' + message);
+  }
+
+  if ((shouldThrow && actual && expected &&
+      !expectedException(actual, expected)) || (!shouldThrow && actual)) {
+    throw actual;
+  }
+}
+
+// 11. Expected to throw an error:
+// assert.throws(block, Error_opt, message_opt);
+
+assert.throws = function(block, /*optional*/error, /*optional*/message) {
+  _throws.apply(this, [true].concat(pSlice.call(arguments)));
+};
+
+// EXTENSION! This is annoying to write outside this module.
+assert.doesNotThrow = function(block, /*optional*/error, /*optional*/message) {
+  _throws.apply(this, [false].concat(pSlice.call(arguments)));
+};
+
+assert.ifError = function (err) { if (err) {throw err;}};
+
+
+/**
+ * Return true if every element in the expected array also exists in the the actual 
+ * array. The actual array may contain more elements that are not in the expected
+ * array. This implementation is very simple and not very efficient (Order(n^2)) so 
+ * do not call this to compare large arrays.
+ * 
+ * @param {Array.<Object>} actual The actual array to test
+ * @param {Array.<Object>} expected The array to test against
+ * @returns True if every element of the expected array exists in the actual array.
+ */
+function isEqualIgnoringOrder(actual, expected) {
+    var found = false;
+    for (var i = 0; i < expected.length; i++) {
+        var found = false;
+        for (var j = 0; j < actual.length; j++) {
+            try {
+                if (_deepEqual(actual[j], expected[i])) {
+                    found = true;
+                    break;
+                }
+            } catch (ignored) {
+            }
+        }
+        if (!found) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function isArray(object) {
+    return typeof(object) === 'object' && Object.prototype.toString.call(object) === '[object Array]';
+};
+
+/**
+ * Performs a deep comparison of arrays, ignoring the order of the
+ * elements of the array. Essentially, this ensure that they have the same
+ * contents, possibly in a different order. Each of the elements of the
+ * array is compared with a deep equals. If this is called with objects
+ * that are not arrays, the assertion fails.
+ *
+ * @example // passing assertions
+ * assert.equalIgnoringOrder([5, 2, 8, 3], [2, 4, 5, 9]);
+ * assert.equalIgnoringOrder(["apples", "bananas", "oranges"], ["oranges", "apples", "bananas"]);
+ *
+ * @param {Object} actual The actual value
+ * @param {Object} expected The expected value
+ * @throws ArgumentsError
+ * @throws AssertionError
+ */
+assert.equalIgnoringOrder = function(actual, expected, message) {
+    if (!isArray(expected)) {
+        fail("Invalid expected argument to equalIgnoringOrder.");
+    } else if (isArray(actual)) {
+        if (isEqualIgnoringOrder(actual, expected) === false) {
+            fail(actual, expected, message, "equalIgnoringOrder", assert.equalIgnoringOrder);
+        }
+    } else {
+        fail(actual, expected, message, "equalIgnoringOrder", assert.equalIgnoringOrder);
+    }
+    return;
+};
+
+/**
+ * Performs a numeric equivalence within the given tolerance. If the
+ * difference between the arguments is within that tolerance, the assertion
+ * passes. Otherwise, it fails.
+ *
+ * @example // passing assertion
+ * assert.roughlyEqual(5.23456789, 5.2345947, 0.001);
+ *
+ * @param {Number} actual The actual value
+ * @param {Number} expected The expected value
+ * @param {Number} tolerance The tolerance for the difference between the two
+ * @throws ArgumentsError
+ * @throws AssertionError
+ */
+assert.roughlyEqual = function(actual, expected, tolerance, message) {
+    if (typeof(actual) !== "number" || typeof(expected) !== "number" || typeof(tolerance) !== "number") {
+        fail("Invalid expected argument to roughlyEquals.");
+    } else if (Math.abs(expected - actual) >= tolerance) {
+        fail(actual, expected, message, "roughlyEquals", assert.roughlyEquals);
+    }
+    return;
+};
+
+/**
+ * Check the actual result to see that every property that exists in the expected
+ * object also exists in the actual object and that it has the same value. If the
+ * expected object is a string, it names the property that should exist without
+ * giving the value. If the expected object is an array, each item in the expected
+ * array should exist in the actual array. If expected is an object, then the actual
+ * object must have all properties that the expected object has and with the same
+ * value. The actual object may have more properties that do not exist in 
+ * expected, but this function
+ * is used to test for only the properties that the unit test cares about.
+ *
+ * @example // passing assertion
+ * assert.contains({a: 2, b: 3}, "b");
+ *
+ * @param {Object} actual The actual value to test which may be an array or an object
+ * @param {*} expected The name of the property that is expected to be within the object in the actual parameter
+ * @param {string} message message to print when the assertion fails
+ * @throws ArgumentsError
+ * @throws AssertionError
+ */
+assert.contains = function(actual, expected, message) {
+    if (isArray(actual)) {
+        if (typeof(expected) === "undefined") {
+            fail("Invalid expected argument to contains.");
+        }
+        
+        if (typeof(expected) === "object") {
+            fail(actual, expected, message + " Expected is object and actual is array.", "contains", assert.contains);
+        } else if (isArray(expected)) {
+            for (var i = 0; i < expected.length; i++) {
+                if (actual.indexOf(expected[i]) < 0) {
+                    fail(actual, expected, message + " Actual array does not contain array index " + i + " of expected.", "contains", assert.contains);
+                }
+            }
+        } else {
+            // primitive type -- check to see if it is in the actual array
+            if (actual.indexOf(expected) < 0) {
+                fail(actual, expected, message + " Expected value " + expected + " is not contained in the array in actual.", "contains", assert.contains);
+            }
+        }
+    } else if (typeof(actual) === "object") {
+        if (typeof(expected) === "object") {
+            for (p in expected) {
+                if (p && expected.hasOwnProperty(p)) {
+                    if (typeof(actual[p]) === 'undefined') {
+                        // "actual does not contain expected properties";
+                        fail(actual[p], expected[p], message + " Expected contains property " + p + " and actual does not.", "contains", assert.contains);
+                    } else if (typeof(expected[p]) === 'object') {
+                        if (!_deepEqual(actual[p], expected[p])) {
+                            fail(actual, expected, message, "contains", assert.notDeepEqual);
+                        }
+                    } else {
+                        if (actual[p] != expected[p]) {
+                            fail(actual, expected, message, "contains", assert.notDeepEqual);
+                        }
+                    }
+                }
+            }
+        } else if (isArray(expected)) {
+            fail(actual, expected, message + " Expected is array and actual is object.", "contains", assert.contains);
+        } else if (typeof(expected) === "string") {
+            if (typeof(actual[p]) === "undefined") {
+                fail(actual[p], expected[p], message + " Expected is looking for property " + expected + " and actual does not contain it.", "contains", assert.contains);
+            }
+        } else {
+            fail("Invalid expected argument to contains.");
+        }
+    } else {
+        fail("Invalid expected argument to contains.");
+    }
+    return;
+};
+})(assert);
+(function(exports){
+/*!
+ * Nodeunit
+ * Copyright (c) 2010 Caolan McMahon
+ * MIT Licensed
+ *
+ * THIS FILE SHOULD BE BROWSER-COMPATIBLE JS!
+ * Only code on that line will be removed, it's mostly to avoid requiring code
+ * that is node specific
+ */
+
+/**
+ * Module dependencies
+ */
+
+
+
+/**
+ * Creates assertion objects representing the result of an assert call.
+ * Accepts an object or AssertionError as its argument.
+ *
+ * @param {object} obj
+ * @api public
+ */
+
+exports.assertion = function (obj) {
+    return {
+        method: obj.method || '',
+        message: obj.message || (obj.error && obj.error.message) || '',
+        error: obj.error,
+        passed: function () {
+            return !this.error;
+        },
+        failed: function () {
+            return Boolean(this.error);
+        }
+    };
+};
+
+/**
+ * Creates an assertion list object representing a group of assertions.
+ * Accepts an array of assertion objects.
+ *
+ * @param {Array} arr
+ * @param {Number} duration
+ * @api public
+ */
+
+exports.assertionList = function (arr, duration) {
+    var that = arr || [];
+    that.failures = function () {
+        var failures = 0;
+        for (var i = 0; i < this.length; i += 1) {
+            if (this[i].failed()) {
+                failures += 1;
+            }
+        }
+        return failures;
+    };
+    that.passes = function () {
+        return that.length - that.failures();
+    };
+    that.duration = duration || 0;
+    return that;
+};
+
+/**
+ * Create a wrapper function for assert module methods. Executes a callback
+ * after it's complete with an assertion object representing the result.
+ *
+ * @param {Function} callback
+ * @api private
+ */
+
+var assertWrapper = function (callback) {
+    return function (new_method, assert_method, arity) {
+        return function () {
+            var message = arguments[arity - 1];
+            var a = exports.assertion({method: new_method, message: message});
+            try {
+                assert[assert_method].apply(null, arguments);
+            }
+            catch (e) {
+                a.error = e;
+            }
+            callback(a);
+        };
+    };
+};
+
+/**
+ * Creates the 'test' object that gets passed to every test function.
+ * Accepts the name of the test function as its first argument, followed by
+ * the start time in ms, the options object and a callback function.
+ *
+ * @param {String} name
+ * @param {Number} start
+ * @param {Object} options
+ * @param {Function} callback
+ * @api public
+ */
+
+exports.test = function (name, start, options, callback) {
+    var expecting;
+    var a_list = [];
+
+    var wrapAssert = assertWrapper(function (a) {
+        a_list.push(a);
+        if (options.log) {
+            async.nextTick(function () {
+                options.log(a);
+            });
+        }
+    });
+
+    var test = {
+        done: function (err) {
+            if (expecting !== undefined && expecting !== a_list.length) {
+                var e = new Error(
+                    'Expected ' + expecting + ' assertions, ' +
+                    a_list.length + ' ran'
+                );
+                var a1 = exports.assertion({method: 'expect', error: e});
+                a_list.push(a1);
+                if (options.log) {
+                    async.nextTick(function () {
+                        options.log(a1);
+                    });
+                }
+            }
+            if (err) {
+                var a2 = exports.assertion({error: err});
+                a_list.push(a2);
+                if (options.log) {
+                    async.nextTick(function () {
+                        options.log(a2);
+                    });
+                }
+            }
+            var end = new Date().getTime();
+            async.nextTick(function () {
+                var assertion_list = exports.assertionList(a_list, end - start);
+                options.testDone(name, assertion_list);
+                callback(null, a_list);
+            });
+        },
+        ok: wrapAssert('ok', 'ok', 2),
+        same: wrapAssert('same', 'deepEqual', 3),
+        equals: wrapAssert('equals', 'equal', 3),
+        expect: function (num) {
+            expecting = num;
+        },
+        _assertion_list: a_list
+    };
+    // add all functions from the assert module
+    for (var k in assert) {
+        if (assert.hasOwnProperty(k)) {
+            test[k] = wrapAssert(k, k, assert[k].length);
+        }
+    }
+    return test;
+};
+
+/**
+ * Ensures an options object has all callbacks, adding empty callback functions
+ * if any are missing.
+ *
+ * @param {Object} opt
+ * @return {Object}
+ * @api public
+ */
+
+exports.options = function (opt) {
+    var optionalCallback = function (name) {
+        opt[name] = opt[name] || function () {};
+    };
+
+    optionalCallback('moduleStart');
+    optionalCallback('moduleDone');
+    optionalCallback('testStart');
+    optionalCallback('testReady');
+    optionalCallback('testDone');
+    //optionalCallback('log');
+
+    // 'done' callback is not optional.
+
+    return opt;
+};
+})(types);
+(function(exports){
+/*!
+ * Nodeunit
+ * Copyright (c) 2010 Caolan McMahon
+ * MIT Licensed
+ *
+ * THIS FILE SHOULD BE BROWSER-COMPATIBLE JS!
+ * Only code on that line will be removed, it's mostly to avoid requiring code
+ * that is node specific
+ */
+
+/**
+ * Module dependencies
+ */
+
+
+
+/**
+ * Added for browser compatibility
+ */
+
+var _keys = function (obj) {
+    if (Object.keys) {
+        return Object.keys(obj);
+    }
+    var keys = [];
+    for (var k in obj) {
+        if (obj.hasOwnProperty(k)) {
+            keys.push(k);
+        }
+    }
+    return keys;
+};
+
+
+var _copy = function (obj) {
+    var nobj = {};
+    var keys = _keys(obj);
+    for (var i = 0; i <  keys.length; i += 1) {
+        nobj[keys[i]] = obj[keys[i]];
+    }
+    return nobj;
+};
+
+
+/**
+ * Runs a test function (fn) from a loaded module. After the test function
+ * calls test.done(), the callback is executed with an assertionList as its
+ * second argument.
+ *
+ * @param {String} name
+ * @param {Function} fn
+ * @param {Object} opt
+ * @param {Function} callback
+ * @api public
+ */
+
+exports.runTest = function (name, fn, opt, callback) {
+    var options = types.options(opt);
+
+    options.testStart(name);
+    var start = new Date().getTime();
+    var test = types.test(name, start, options, callback);
+
+    options.testReady(test);
+    try {
+        fn(test);
+    }
+    catch (e) {
+        test.done(e);
+    }
+};
+
+/**
+ * Takes an object containing test functions or other test suites as properties
+ * and runs each in series. After all tests have completed, the callback is
+ * called with a list of all assertions as the second argument.
+ *
+ * If a name is passed to this function it is prepended to all test and suite
+ * names that run within it.
+ *
+ * @param {String} name
+ * @param {Object} suite
+ * @param {Object} opt
+ * @param {Function} callback
+ * @api public
+ */
+
+exports.runSuite = function (name, suite, opt, callback) {
+    suite = wrapGroup(suite);
+    var keys = _keys(suite);
+
+    async.concatSeries(keys, function (k, cb) {
+        var prop = suite[k], _name;
+
+        _name = name ? [].concat(name, k) : [k];
+        _name.toString = function () {
+            // fallback for old one
+            return this.join(' - ');
+        };
+
+        if (typeof prop === 'function') {
+            var in_name = false,
+                in_specific_test = (_name.toString() === opt.testFullSpec) ? true : false;
+            for (var i = 0; i < _name.length; i += 1) {
+                if (_name[i] === opt.testspec) {
+                    in_name = true;
+                }
+            }
+
+            if ((!opt.testFullSpec || in_specific_test) && (!opt.testspec || in_name)) {
+                if (opt.moduleStart) {
+                    opt.moduleStart();
+                }
+                exports.runTest(_name, suite[k], opt, cb);
+            }
+            else {
+                return cb();
+            }
+        }
+        else {
+            exports.runSuite(_name, suite[k], opt, cb);
+        }
+    }, callback);
+};
+
+/**
+ * Run each exported test function or test suite from a loaded module.
+ *
+ * @param {String} name
+ * @param {Object} mod
+ * @param {Object} opt
+ * @param {Function} callback
+ * @api public
+ */
+
+exports.runModule = function (name, mod, opt, callback) {
+    var options = _copy(types.options(opt));
+
+    var _run = false;
+    var _moduleStart = options.moduleStart;
+
+    mod = wrapGroup(mod);
+
+    function run_once() {
+        if (!_run) {
+            _run = true;
+            _moduleStart(name);
+        }
+    }
+    options.moduleStart = run_once;
+
+    var start = new Date().getTime();
+
+    exports.runSuite(null, mod, options, function (err, a_list) {
+        var end = new Date().getTime();
+        var assertion_list = types.assertionList(a_list, end - start);
+        options.moduleDone(name, assertion_list);
+        if (nodeunit.complete) {
+            nodeunit.complete(name, assertion_list);
+        }
+        callback(null, a_list);
+    });
+};
+
+/**
+ * Treats an object literal as a list of modules keyed by name. Runs each
+ * module and finished with calling 'done'. You can think of this as a browser
+ * safe alternative to runFiles in the nodeunit module.
+ *
+ * @param {Object} modules
+ * @param {Object} opt
+ * @api public
+ */
+
+// TODO: add proper unit tests for this function
+exports.runModules = function (modules, opt) {
+    var all_assertions = [];
+    var options = types.options(opt);
+    var start = new Date().getTime();
+
+    async.concatSeries(_keys(modules), function (k, cb) {
+        exports.runModule(k, modules[k], options, cb);
+    },
+    function (err, all_assertions) {
+        var end = new Date().getTime();
+        options.done(types.assertionList(all_assertions, end - start));
+    });
+};
+
+
+/**
+ * Wraps a test function with setUp and tearDown functions.
+ * Used by testCase.
+ *
+ * @param {Function} setUp
+ * @param {Function} tearDown
+ * @param {Function} fn
+ * @api private
+ */
+
+var wrapTest = function (setUp, tearDown, fn) {
+    return function (test) {
+        var context = {};
+        if (tearDown) {
+            var done = test.done;
+            test.done = function (err) {
+                try {
+                    tearDown.call(context, function (err2) {
+                        if (err && err2) {
+                            test._assertion_list.push(
+                                types.assertion({error: err})
+                            );
+                            return done(err2);
+                        }
+                        done(err || err2);
+                    });
+                }
+                catch (e) {
+                    done(e);
+                }
+            };
+        }
+        if (setUp) {
+            setUp.call(context, function (err) {
+                if (err) {
+                    return test.done(err);
+                }
+                fn.call(context, test);
+            });
+        }
+        else {
+            fn.call(context, test);
+        }
+    };
+};
+
+
+/**
+ * Returns a serial callback from two functions.
+ *
+ * @param {Function} funcFirst
+ * @param {Function} funcSecond
+ * @api private
+ */
+
+var getSerialCallback = function (fns) {
+    if (!fns.length) {
+        return null;
+    }
+    return function (callback) {
+        var that = this;
+        var bound_fns = [];
+        for (var i = 0, len = fns.length; i < len; i++) {
+            (function (j) {
+                bound_fns.push(function () {
+                    return fns[j].apply(that, arguments);
+                });
+            })(i);
+        }
+        return async.series(bound_fns, callback);
+    };
+};
+
+
+/**
+ * Wraps a group of tests with setUp and tearDown functions.
+ * Used by testCase.
+ *
+ * @param {Object} group
+ * @param {Array} setUps - parent setUp functions
+ * @param {Array} tearDowns - parent tearDown functions
+ * @api private
+ */
+
+var wrapGroup = function (group, setUps, tearDowns) {
+    var tests = {};
+
+    var setUps = setUps ? setUps.slice(): [];
+    var tearDowns = tearDowns ? tearDowns.slice(): [];
+
+    if (group.setUp) {
+        setUps.push(group.setUp);
+        delete group.setUp;
+    }
+    if (group.tearDown) {
+        tearDowns.unshift(group.tearDown);
+        delete group.tearDown;
+    }
+
+    var keys = _keys(group);
+
+    for (var i = 0; i < keys.length; i += 1) {
+        var k = keys[i];
+        if (typeof group[k] === 'function') {
+            tests[k] = wrapTest(
+                getSerialCallback(setUps),
+                getSerialCallback(tearDowns),
+                group[k]
+            );
+        }
+        else if (typeof group[k] === 'object') {
+            tests[k] = wrapGroup(group[k], setUps, tearDowns);
+        }
+    }
+    return tests;
+};
+
+
+/**
+ * Backwards compatibility for test suites using old testCase API
+ */
+
+exports.testCase = function (suite) {
+    return suite;
+};
+})(core);
+(function(exports){
+/*!
+ * Nodeunit
+ * Copyright (c) 2010 Caolan McMahon
+ * MIT Licensed
+ *
+ * THIS FILE SHOULD BE BROWSER-COMPATIBLE JS!
+ * Only code on that line will be removed, its mostly to avoid requiring code
+ * that is node specific
+ */
+
+
+/**
+ * NOTE: this test runner is not listed in index.js because it cannot be
+ * used with the command-line tool, only inside the browser.
+ */
+
+
+/**
+ * Reporter info string
+ */
+
+exports.info = "Browser-based test reporter";
+
+
+/**
+ * Run all tests within each module, reporting the results
+ *
+ * @param {Array} files
+ * @api public
+ */
+
+exports.run = function (modules, options, callback) {
+    var start = new Date().getTime(), div;
+	options = options || {};
+	div = options.div || document.body;
+
+    function setText(el, txt) {
+        if ('innerText' in el) {
+            el.innerText = txt;
+        }
+        else if ('textContent' in el){
+            el.textContent = txt;
+        }
+    }
+
+    function getOrCreate(tag, id) {
+        var el = document.getElementById(id);
+        if (!el) {
+            el = document.createElement(tag);
+            el.id = id;
+            div.appendChild(el);
+        }
+        return el;
+    };
+
+    var header = getOrCreate('h1', 'nodeunit-header');
+    var banner = getOrCreate('h2', 'nodeunit-banner');
+    var userAgent = getOrCreate('h2', 'nodeunit-userAgent');
+    var tests = getOrCreate('ol', 'nodeunit-tests');
+    var result = getOrCreate('p', 'nodeunit-testresult');
+
+    setText(userAgent, navigator.userAgent);
+
+    var notMap = {
+    	"==": "!=",
+    	"!=": "==",
+    	"<":  ">=",
+    	">":  "<=",
+    	"<=": ">",
+    	">=": "<",
+    	"in": "not in"
+    };
+    
+    nodeunit.runModules(modules, {
+        moduleStart: function (name) {
+            /*var mheading = document.createElement('h2');
+            mheading.innerText = name;
+            results.appendChild(mheading);
+            module = document.createElement('ol');
+            results.appendChild(module);*/
+        },
+        testDone: function (name, assertions) {
+            var test = document.createElement('li');
+            var strong = document.createElement('strong');
+            strong.innerHTML = name + ' <b style="color: black;">(' +
+                '<b class="fail">' + assertions.failures() + '</b>, ' +
+                '<b class="pass">' + assertions.passes() + '</b>, ' +
+                assertions.length +
+            ')</b>';
+            test.className = assertions.failures() ? 'fail': 'pass';
+            test.appendChild(strong);
+
+            var aList = document.createElement('ol');
+            aList.style.display = 'none';
+            test.onclick = function () {
+                var d = aList.style.display;
+                aList.style.display = (d == 'none') ? 'block': 'none';
+            };
+            for (var i=0; i<assertions.length; i++) {
+                var li = document.createElement('li');
+                var a = assertions[i];
+                if (a.failed()) {
+                    li.innerHTML = (a.message || a.method || 'no message') + " " +
+                    	a.error.actual + " (actual) " + (notMap[a.error.operator] || a.error.operator) + 
+                    	" " + a.error.expected + " (expected)" +
+                    	//JSON.stringify(a) + " " +
+                        '<pre>' + (a.error.stack || a.error) + '</pre>';
+                    li.className = 'fail';
+                }
+                else {
+                    li.innerHTML = a.message || a.method || 'no message';
+                    li.className = 'pass';
+                }
+                aList.appendChild(li);
+            }
+            test.appendChild(aList);
+            tests.appendChild(test);
+        },
+        done: function (assertions) {
+            var end = new Date().getTime();
+            var duration = end - start;
+
+            var failures = assertions.failures();
+            banner.className = failures ? 'fail': 'pass';
+
+            result.innerHTML = 'Tests completed in ' + duration +
+                ' milliseconds.<br/><span class="passed">' +
+                assertions.passes() + '</span> assertions of ' +
+                '<span class="all">' + assertions.length + '<span> passed, ' +
+                assertions.failures() + ' failed.';
+
+            if (callback) callback(assertions.failures() ? new Error('We have got test failures.') : undefined);
+        }
+    });
+};
+})(reporter);
+nodeunit = core;
+nodeunit.assert = assert;
+nodeunit.reporter = reporter;
+nodeunit.run = reporter.run;
+return nodeunit; })();

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,1 @@
+{"type": "module"}

--- a/test/testSuite.cjs
+++ b/test/testSuite.cjs
@@ -1,0 +1,43 @@
+/*
+ * testSuite.js - test suite for this directory under commonjs versions
+ * of nodejs
+ *
+ * Copyright © 2022, JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// this processes all subsequent requires using babel
+process.env.BABEL_ENV = "test";
+require("@babel/register")({
+    presets: [
+        '@babel/preset-env',
+    ],
+    compact: false,
+    minified: false,
+    plugins: [
+        ["module-resolver", {
+            "root": "test",
+            // map the src dir to the lib dir so we can
+            // test the commonjs code
+            "alias": {
+                "../src": "../lib"
+            }
+        }]
+    ]
+});
+
+// call the ESM tests and use babel to make this version of node
+// be able to run it
+require("./testSuite.js");

--- a/test/testSuite.html
+++ b/test/testSuite.html
@@ -1,0 +1,36 @@
+<!--
+testSuite.html - Run all tests
+
+Copyright © 2022 JEDLSoft
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<html>
+  <head>
+    <title>Test Suite</title>
+    <link rel="stylesheet" href="./nodeunit/nodeunit.css" type="text/css" />
+    <script>
+    var log4js = null;
+    </script>
+    <script src="./nodeunit/nodeunit.js"></script>
+    <script src="./xliff-test.js"></script>
+  </head>
+  <body>
+    <h1 id="nodeunit-header">iLib All Test Suites</h1>
+    <script>
+     nodeunit.run(XliffTest);
+    </script>
+  </body>
+</html>

--- a/test/testSuite.js
+++ b/test/testSuite.js
@@ -1,0 +1,46 @@
+/*
+ * testSuite.js - test suite for this directory
+ *
+ * Copyright © 2022, JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import nodeunit from 'nodeunit';
+import assert from 'nodeunit/lib/assert.js';
+import assertextras from 'assertextras';
+import { files } from './testSuiteFiles.js';
+
+assertextras(assert);
+
+const reporter = nodeunit.reporters.minimal;
+let modules = {};
+
+let promise = Promise.resolve(true);
+
+files.forEach(path => {
+    promise = promise.then(() => {
+        return import("./" + path).then(test => {
+            for (let suite in test) {
+                modules[suite] = test[suite];
+            }
+        });
+    });
+});
+
+promise.then(() => {
+    reporter.run(modules, undefined, err => {
+        process.exit(err ? 1 : 0);
+    });
+});

--- a/test/testSuite.sh
+++ b/test/testSuite.sh
@@ -1,0 +1,11 @@
+VERSION=$(node -v | sed 's/v//' | sed 's/\..*//')
+if [ $VERSION -lt 12 ]
+then
+    # testing under commonjs by transpiling with babel first
+    echo node test/testSuite.cjs
+    node test/testSuite.cjs
+else
+    # testing native ESM modules
+    echo node test/testSuite.js
+    node test/testSuite.js
+fi

--- a/test/testSuiteFiles.js
+++ b/test/testSuiteFiles.js
@@ -1,0 +1,23 @@
+/*
+ * testSuiteFiles.js - list the test files in this directory
+ * 
+ * Copyright © 2022, JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const files = [
+    "testXliff10.js",
+    "testXliff20.js"
+];

--- a/test/testSuiteWeb.js
+++ b/test/testSuiteWeb.js
@@ -1,0 +1,26 @@
+/*
+ * testSuiteWeb.js - test suite for this directory
+ *
+ * Copyright © 2022, JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { testXliff10 } from './testXliff10.js';
+import { testXliff20 } from './testXliff20.js';
+
+export const tests = [
+    testXliff10,
+    testXliff20
+];

--- a/test/testXliff10.js
+++ b/test/testXliff10.js
@@ -21,9 +21,9 @@ import Xliff from "../src/Xliff.js";
 import TranslationUnit from "../src/TranslationUnit.js";
 
 function diff(a, b) {
-    var min = Math.min(a.length, b.length);
+    let min = Math.min(a.length, b.length);
 
-    for (var i = 0; i < min; i++) {
+    for (let i = 0; i < min; i++) {
         if (a[i] !== b[i]) {
             console.log("Found difference at character " + i);
             console.log("a: " + a.substring(i));
@@ -77,13 +77,50 @@ export const testXliff10 = {
         test.done();
     },
 
+    testXliffGetVersionDefault: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+        
+        test.equal(x.getVersion(), "1.2");
+
+        test.done();
+    },
+
+    testXliffGetVersion12: function(test) {
+        test.expect(2);
+
+        const x = new Xliff({
+            version: "1.2"
+        });
+        test.ok(x);
+        
+        test.equal(x.getVersion(), "1.2");
+
+        test.done();
+    },
+
+    testXliffGetVersion20: function(test) {
+        test.expect(2);
+
+        const x = new Xliff({
+            version: "2.0"
+        });
+        test.ok(x);
+        
+        test.equal(x.getVersion(), "2.0");
+
+        test.done();
+    },
+
     testXliffAddTranslationUnit: function(test) {
         test.expect(11);
 
         const x = new Xliff();
         test.ok(x);
 
-        var tu = new TranslationUnit({
+        let tu = new TranslationUnit({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             key: "foobar",
@@ -97,7 +134,7 @@ export const testXliff10 = {
 
         x.addTranslationUnit(tu);
 
-        var tulist = x.getTranslationUnits();
+        const tulist = x.getTranslationUnits();
 
         test.ok(tulist);
 
@@ -114,6 +151,344 @@ export const testXliff10 = {
         test.done();
     },
 
+    testXliffAddTranslationUnitMultiple: function(test) {
+        test.expect(19);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        let tu = new TranslationUnit({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            file: "foo/bar/asdf.java",
+            project: "webapp",
+            resType: "string",
+            state: "new",
+            comment: "This is a comment",
+            datatype: "java"
+        });
+
+        x.addTranslationUnit(tu);
+
+        tu = new TranslationUnit({
+            source: "foobar",
+            sourceLocale: "en-US",
+            key: "asdf",
+            file: "x.java",
+            project: "webapp",
+            resType: "array",
+            state: "translated",
+            comment: "No comment",
+            datatype: "javascript"
+        });
+
+        x.addTranslationUnit(tu);
+
+        const tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 2);
+        test.equal(tulist[0].source, "Asdf asdf");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "foobar");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].state, "new");
+        test.equal(tulist[0].comment, "This is a comment");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].datatype, "java");
+
+        test.equal(tulist[1].source, "foobar");
+        test.equal(tulist[1].sourceLocale, "en-US");
+        test.equal(tulist[1].key, "asdf");
+        test.equal(tulist[1].file, "x.java");
+        test.equal(tulist[1].state, "translated");
+        test.equal(tulist[1].comment, "No comment");
+        test.equal(tulist[1].project, "webapp");
+        test.equal(tulist[1].datatype, "javascript");
+
+        test.done();
+    },
+
+    testXliffAddTranslationUnitAddSameTUTwice: function(test) {
+        test.expect(11);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        let tu = new TranslationUnit({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            file: "foo/bar/asdf.java",
+            project: "webapp",
+            resType: "string",
+            state: "new",
+            comment: "This is a comment",
+            datatype: "java"
+        });
+
+        x.addTranslationUnit(tu);
+        x.addTranslationUnit(tu); // second time should not add anything
+
+        const tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+        test.equal(tulist[0].source, "Asdf asdf");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "foobar");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].state, "new");
+        test.equal(tulist[0].comment, "This is a comment");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].datatype, "java");
+
+        test.done();
+    },
+
+    testXliffAddTranslationUnits: function(test) {
+        test.expect(19);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        
+        x.addTranslationUnits([
+            new TranslationUnit({
+                source: "Asdf asdf",
+                sourceLocale: "en-US",
+                key: "foobar",
+                file: "foo/bar/asdf.java",
+                project: "webapp",
+                resType: "string",
+                state: "new",
+                comment: "This is a comment",
+                datatype: "java"
+            }),
+            new TranslationUnit({
+                source: "foobar",
+                sourceLocale: "en-US",
+                key: "asdf",
+                file: "x.java",
+                project: "webapp",
+                resType: "array",
+                state: "translated",
+                comment: "No comment",
+                datatype: "javascript"
+            })
+        ]);
+
+        const tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 2);
+        test.equal(tulist[0].source, "Asdf asdf");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "foobar");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].state, "new");
+        test.equal(tulist[0].comment, "This is a comment");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].datatype, "java");
+
+        test.equal(tulist[1].source, "foobar");
+        test.equal(tulist[1].sourceLocale, "en-US");
+        test.equal(tulist[1].key, "asdf");
+        test.equal(tulist[1].file, "x.java");
+        test.equal(tulist[1].state, "translated");
+        test.equal(tulist[1].comment, "No comment");
+        test.equal(tulist[1].project, "webapp");
+        test.equal(tulist[1].datatype, "javascript");
+
+        test.done();
+    },
+
+    testXliffSize: function(test) {
+        test.expect(3);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        test.equal(x.size(), 0);
+
+        x.addTranslationUnits([
+            new TranslationUnit({
+                source: "Asdf asdf",
+                sourceLocale: "en-US",
+                key: "foobar",
+                file: "foo/bar/asdf.java",
+                project: "webapp",
+                resType: "string",
+                state: "new",
+                comment: "This is a comment",
+                datatype: "java"
+            }),
+            new TranslationUnit({
+                source: "foobar",
+                sourceLocale: "en-US",
+                key: "asdf",
+                file: "x.java",
+                project: "webapp",
+                resType: "array",
+                state: "translated",
+                comment: "No comment",
+                datatype: "javascript"
+            })
+        ]);
+
+        test.equal(x.size(), 2);
+
+        test.done();
+    },
+
+    testXliffSerializeSourceOnly: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        const tu = new TranslationUnit({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            file: "foo/bar/asdf.java",
+            project: "webapp",
+            resType: "string",
+            state: "new",
+            comment: "This is a comment",
+            datatype: "java"
+        })
+
+        x.addTranslationUnit(tu);
+
+        let actual = x.serialize();
+        let expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="1.2">\n' +
+            '  <file original="foo/bar/asdf.java" source-language="en-US" product-name="webapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="1" resname="foobar" restype="string" datatype="java">\n' +
+            '        <source>Asdf asdf</source>\n' +
+            '        <note>This is a comment</note>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliffSerializeFull: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        const tu = new TranslationUnit({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            target: "bam bam",
+            targetLocale: "de-DE",
+            key: "foobar",
+            file: "foo/bar/asdf.java",
+            project: "webapp",
+            resType: "string",
+            state: "new",
+            comment: "This is a comment",
+            datatype: "java"
+        })
+
+        x.addTranslationUnit(tu);
+
+        let actual = x.serialize();
+        let expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="1.2">\n' +
+            '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="webapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="1" resname="foobar" restype="string" datatype="java">\n' +
+            '        <source>Asdf asdf</source>\n' +
+            '        <target state="new">bam bam</target>\n' +
+            '        <note>This is a comment</note>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliffSerializeWithSourceAndTargetAndComment: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        let tu = new TranslationUnit({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            target: "foobarfoo",
+            targetLocale: "de-DE",
+            key: "foobar",
+            file: "foo/bar/asdf.java",
+            project: "webapp",
+            comment: "foobar is where it's at!"
+        });
+
+        x.addTranslationUnit(tu);
+
+        tu = new TranslationUnit({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            target: "bebe bebe",
+            targetLocale: "fr-FR",
+            key: "huzzah",
+            file: "foo/bar/j.java",
+            project: "webapp",
+            comment: "come & enjoy it with us"
+        });
+
+        x.addTranslationUnit(tu);
+
+        let expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="string">\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '        <target>foobarfoo</target>\n' +
+                '        <note>foobar is where it\'s at!</note>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>baby baby</source>\n' +
+                '        <target>bebe bebe</target>\n' +
+                '        <note>come &amp; enjoy it with us</note>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>';
+
+        let actual = x.serialize();
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
 /*
     testXliffSize: function(test) {
         test.expect(3);
@@ -121,7 +496,7 @@ export const testXliff10 = {
         const x = new Xliff();
         test.ok(x);
 
-        var res = new ResourceString({
+        let res = new ResourceString({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             key: "foobar",
@@ -148,7 +523,7 @@ export const testXliff10 = {
         const x = new Xliff();
         test.ok(x);
 
-        var res = new ResourceString({
+        let res = new ResourceString({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             key: "foobar",
@@ -168,7 +543,7 @@ export const testXliff10 = {
 
         x.addResource(res);
 
-        var reslist = x.getResources({
+        let reslist = x.getResources({
             reskey: "foobar"
         });
 
@@ -191,7 +566,7 @@ export const testXliff10 = {
         test.ok(x);
         test.equal(x.size(), 0);
 
-        var res = new ResourceString({
+        let res = new ResourceString({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             key: "foobar",
@@ -222,7 +597,7 @@ export const testXliff10 = {
         const x = new Xliff();
         test.ok(x);
 
-        var res = new ResourceString({
+        let res = new ResourceString({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             key: "foobar",
@@ -245,7 +620,7 @@ export const testXliff10 = {
 
         x.addResource(res);
 
-        var reslist = x.getResources({
+        let reslist = x.getResources({
             reskey: "foobar"
         });
 
@@ -270,7 +645,7 @@ export const testXliff10 = {
 
         test.equal(x.size(), 0);
 
-        var res = new ResourceString({
+        let res = new ResourceString({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             key: "foobar",
@@ -306,7 +681,7 @@ export const testXliff10 = {
         const x = new Xliff();
         test.ok(x);
 
-        var res = new ResourceString({
+        let res = new ResourceString({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             key: "foobar",
@@ -329,7 +704,7 @@ export const testXliff10 = {
 
         x.addResource(res);
 
-        var reslist = x.getResources({
+        let reslist = x.getResources({
             reskey: "foobar"
         });
 
@@ -360,7 +735,7 @@ export const testXliff10 = {
         });
         test.ok(x);
 
-        var res = new ResourceString({
+        let res = new ResourceString({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             key: "foobar",
@@ -394,7 +769,7 @@ export const testXliff10 = {
         const x = new Xliff();
         test.ok(x);
 
-        var res = new ResourceString({
+        let res = new ResourceString({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             key: "foobar",
@@ -416,7 +791,7 @@ export const testXliff10 = {
 
         x.addResource(res);
 
-        var reslist = x.getResources({
+        let reslist = x.getResources({
             sourceLocale: "en-US"
         });
 
@@ -443,7 +818,7 @@ export const testXliff10 = {
         const x = new Xliff();
         test.ok(x);
 
-        var res = new ContextResourceString({
+        let res = new ContextResourceString({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             target: "gutver",
@@ -456,8 +831,8 @@ export const testXliff10 = {
 
         x.addResource(res);
 
-        var actual = x.serialize();
-        var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
+        let actual = x.serialize();
+        let expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
             '<xliff version="1.2">\n' +
             '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="nl-NL" product-name="androidapp">\n' +
             '    <body>\n' +
@@ -480,7 +855,7 @@ export const testXliff10 = {
         const x = new Xliff();
         test.ok(x);
 
-        var res = new ContextResourceString({
+        let res = new ContextResourceString({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             key: "foobar",
@@ -502,8 +877,8 @@ export const testXliff10 = {
 
         x.addResource(res);
 
-        var actual = x.serialize();
-        var expected =
+        let actual = x.serialize();
+        let expected =
             '<?xml version="1.0" encoding="utf-8"?>\n' +
             '<xliff version="1.2">\n' +
             '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
@@ -533,7 +908,7 @@ export const testXliff10 = {
         const x = new Xliff();
         test.ok(x);
 
-        var res = new ContextResourceString({
+        let res = new ContextResourceString({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             target: "gutver",
@@ -547,8 +922,8 @@ export const testXliff10 = {
 
         x.addResource(res);
 
-        var actual = x.serialize();
-        var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
+        let actual = x.serialize();
+        let expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
             '<xliff version="1.2">\n' +
             '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="nl-NL" product-name="androidapp" x-flavor="chocolate">\n' +
             '    <body>\n' +
@@ -571,7 +946,7 @@ export const testXliff10 = {
         const x = new Xliff();
         test.ok(x);
 
-        var res = new ContextResourceString({
+        let res = new ContextResourceString({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             key: "foobar",
@@ -597,8 +972,8 @@ export const testXliff10 = {
 
         x.addResource(res);
 
-        var actual = x.serialize();
-        var expected =
+        let actual = x.serialize();
+        let expected =
             '<?xml version="1.0" encoding="utf-8"?>\n' +
             '<xliff version="1.2">\n' +
             '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
@@ -637,7 +1012,7 @@ export const testXliff10 = {
         const x = new Xliff();
         test.ok(x);
 
-        var res = new ContextResourceString({
+        let res = new ContextResourceString({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             key: "foobar",
@@ -659,8 +1034,8 @@ export const testXliff10 = {
 
         x.addResource(res);
 
-        var actual = x.serialize();
-        var expected =
+        let actual = x.serialize();
+        let expected =
             '<?xml version="1.0" encoding="utf-8"?>\n' +
             '<xliff version="1.2">\n' +
             '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
@@ -723,8 +1098,8 @@ export const testXliff10 = {
 
         x.addResource(res);
 
-        var actual = x.serialize();
-        var expected =
+        let actual = x.serialize();
+        let expected =
                 '<?xml version="1.0" encoding="utf-8"?>\n' +
                 '<xliff version="1.2">\n' +
                 '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="nl-NL" product-name="androidapp">\n' +
@@ -752,7 +1127,7 @@ export const testXliff10 = {
         const x = new Xliff();
         test.ok(x);
 
-        var res = new ResourceString({
+        let res = new ResourceString({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             target: "foobarfoo",
@@ -829,7 +1204,7 @@ export const testXliff10 = {
         const x = new Xliff();
         test.ok(x);
 
-        var res = new ResourceString({
+        let res = new ResourceString({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             target: "foobarfoo",
@@ -855,7 +1230,7 @@ export const testXliff10 = {
 
         x.addResource(res);
 
-        var expected =
+        let expected =
                 '<?xml version="1.0" encoding="utf-8"?>\n' +
                 '<xliff version="1.2">\n' +
                 '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="webapp">\n' +
@@ -878,7 +1253,7 @@ export const testXliff10 = {
                 '  </file>\n' +
                 '</xliff>';
 
-        var actual = x.serialize();
+        let actual = x.serialize();
 
         diff(actual, expected);
         test.equal(actual, expected);
@@ -912,8 +1287,8 @@ export const testXliff10 = {
 
         x.addResource(res);
 
-        var actual = x.serialize();
-        var expected =
+        let actual = x.serialize();
+        let expected =
                 '<?xml version="1.0" encoding="utf-8"?>\n' +
                 '<xliff version="1.2">\n' +
                 '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="nl-NL" product-name="webapp">\n' +
@@ -963,8 +1338,8 @@ export const testXliff10 = {
 
         x.addResource(res);
 
-        var actual = x.serialize();
-        var expected =
+        let actual = x.serialize();
+        let expected =
                 '<?xml version="1.0" encoding="utf-8"?>\n' +
                 '<xliff version="1.2">\n' +
                 '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
@@ -1018,8 +1393,8 @@ export const testXliff10 = {
 
         x.addResource(res);
 
-        var actual = x.serialize();
-        var expected =
+        let actual = x.serialize();
+        let expected =
                 '<?xml version="1.0" encoding="utf-8"?>\n' +
                 '<xliff version="1.2">\n' +
                 '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="ru-RU" product-name="androidapp">\n' +
@@ -1067,8 +1442,8 @@ export const testXliff10 = {
 
         x.addResource(res);
 
-        var actual = x.serialize();
-        var expected =
+        let actual = x.serialize();
+        let expected =
                 '<?xml version="1.0" encoding="utf-8"?>\n' +
                 '<xliff version="1.2">\n' +
                 '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
@@ -1099,7 +1474,7 @@ export const testXliff10 = {
         const x = new Xliff();
         test.ok(x);
 
-        var res = new ResourceString({
+        let res = new ResourceString({
             source: "Asdf <b>asdf</b>",
             sourceLocale: "en-US",
             target: "Asdf 'quotes'",
@@ -1125,8 +1500,8 @@ export const testXliff10 = {
 
         x.addResource(res);
 
-        var actual = x.serialize();
-        var expected =
+        let actual = x.serialize();
+        let expected =
                 '<?xml version="1.0" encoding="utf-8"?>\n' +
                 '<xliff version="1.2">\n' +
                 '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
@@ -1158,7 +1533,7 @@ export const testXliff10 = {
         const x = new Xliff();
         test.ok(x);
 
-        var res = new ResourceString({
+        let res = new ResourceString({
             source: "Asdf <b>asdf</b>",
             sourceLocale: "en-US",
             target: "Asdf 'quotes'",
@@ -1184,8 +1559,8 @@ export const testXliff10 = {
 
         x.addResource(res);
 
-        var actual = x.serialize();
-        var expected =
+        let actual = x.serialize();
+        let expected =
                 '<?xml version="1.0" encoding="utf-8"?>\n' +
                 '<xliff version="1.2">\n' +
                 '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
@@ -1217,7 +1592,7 @@ export const testXliff10 = {
         const x = new Xliff();
         test.ok(x);
 
-        var res = new ResourceString({
+        let res = new ResourceString({
             source: "Here are \"double\" and 'single' quotes.",
             sourceLocale: "en-US",
             target: "Hier zijn \"dubbel\" en 'singel' quotaties.",
@@ -1252,7 +1627,7 @@ export const testXliff10 = {
         const x = new Xliff();
         test.ok(x);
 
-        var res = new ResourceString({
+        let res = new ResourceString({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             target: "Asdf translated",
@@ -1278,8 +1653,8 @@ export const testXliff10 = {
 
         x.addResource(res);
 
-        var actual = x.serialize();
-        var expected =
+        let actual = x.serialize();
+        let expected =
                 '<?xml version="1.0" encoding="utf-8"?>\n' +
                 '<xliff version="1.2">\n' +
                 '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
@@ -1367,7 +1742,7 @@ export const testXliff10 = {
                 '  </file>\n' +
                 '</xliff>');
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -1424,7 +1799,7 @@ export const testXliff10 = {
                 '</xliff>');
 
         // console.log("x is " + JSON.stringify(x, undefined, 4));
-        var reslist = x.getResources();
+        let reslist = x.getResources();
         // console.log("x is now " + JSON.stringify(x, undefined, 4));
 
         test.ok(reslist);
@@ -1479,7 +1854,7 @@ export const testXliff10 = {
                 '  </file>\n' +
                 '</xliff>');
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -1531,7 +1906,7 @@ export const testXliff10 = {
                 '  </file>\n' +
                 '</xliff>');
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -1583,7 +1958,7 @@ export const testXliff10 = {
                 '  </file>\n' +
                 '</xliff>');
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -1633,7 +2008,7 @@ export const testXliff10 = {
                 '  </file>\n' +
                 '</xliff>');
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -1681,7 +2056,7 @@ export const testXliff10 = {
 
         // console.log("x is " + JSON.stringify(x, undefined, 4));
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         // console.log("after get resources x is " + JSON.stringify(x, undefined, 4));
 
@@ -1728,7 +2103,7 @@ export const testXliff10 = {
 
         // console.log("x is " + JSON.stringify(x, undefined, 4));
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         // console.log("after get resources x is " + JSON.stringify(x, undefined, 4));
 
@@ -1781,7 +2156,7 @@ export const testXliff10 = {
                 '  </file>\n' +
                 '</xliff>');
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -1825,7 +2200,7 @@ export const testXliff10 = {
                 '  </file>\n' +
                 '</xliff>');
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -1875,7 +2250,7 @@ export const testXliff10 = {
                 '  </file>\n' +
                 '</xliff>');
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -1889,7 +2264,7 @@ export const testXliff10 = {
         test.equal(reslist[0].resType, "array");
         test.equal(reslist[0].getOrigin(), "source");
 
-        var items = reslist[0].getSourceArray();
+        let items = reslist[0].getSourceArray();
 
         test.equal(items.length, 4);
         test.equal(items[0], "This is element 0");
@@ -1927,7 +2302,7 @@ export const testXliff10 = {
                 '  </file>\n' +
                 '</xliff>');
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -1941,7 +2316,7 @@ export const testXliff10 = {
         test.equal(reslist[0].resType, "array");
         test.equal(reslist[0].getOrigin(), "source");
 
-        var items = reslist[0].getSourceArray();
+        let items = reslist[0].getSourceArray();
 
         test.equal(items.length, 4);
         test.equal(items[0], null);
@@ -1987,7 +2362,7 @@ export const testXliff10 = {
                 '  </file>\n' +
                 '</xliff>');
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -2037,7 +2412,7 @@ export const testXliff10 = {
                 '  </file>\n' +
                 '</xliff>');
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -2070,13 +2445,13 @@ export const testXliff10 = {
         const x = new Xliff();
         test.ok(x);
 
-        var fs = require("fs");
+        let fs = require("fs");
 
-        var str = fs.readFileSync("testfiles/test.xliff", "utf-8");
+        let str = fs.readFileSync("testfiles/test.xliff", "utf-8");
 
         x.deserialize(str);
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -2112,7 +2487,7 @@ export const testXliff10 = {
                 '  </file>\n' +
                 '</xliff>');
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -2158,7 +2533,7 @@ export const testXliff10 = {
                 '  </file>\n' +
                 '</xliff>');
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -2203,7 +2578,7 @@ export const testXliff10 = {
                 '  </file>\n' +
                 '</xliff>');
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -2241,7 +2616,7 @@ export const testXliff10 = {
                 '  </file>\n' +
                 '</xliff>');
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -2277,7 +2652,7 @@ export const testXliff10 = {
                 '  </file>\n' +
                 '</xliff>');
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -2315,7 +2690,7 @@ export const testXliff10 = {
                 '  </file>\n' +
                 '</xliff>');
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -2354,7 +2729,7 @@ export const testXliff10 = {
                 '  </file>\n' +
                 '</xliff>');
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -2389,7 +2764,7 @@ export const testXliff10 = {
                 '  </file>\n' +
                 '</xliff>');
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -2409,7 +2784,7 @@ export const testXliff10 = {
     testXliffTranslationUnitConstructor: function(test) {
         test.expect(1);
 
-        var tu = new TranslationUnit({
+        let tu = new TranslationUnit({
             "source": "a",
             "sourceLocale": "en-US",
             "key": "foobar",
@@ -2425,7 +2800,7 @@ export const testXliff10 = {
     testXliffTranslationUnitConstructorEverythingCopied: function(test) {
         test.expect(11);
 
-        var tu = new TranslationUnit({
+        let tu = new TranslationUnit({
             "source": "a",
             "sourceLocale": "en-US",
             "key": "foobar",
@@ -2458,7 +2833,7 @@ export const testXliff10 = {
         test.expect(1);
 
         test.throws(function() {
-            var tu = new TranslationUnit({
+            let tu = new TranslationUnit({
                 "source": "a",
                 "sourceLocale": "en-US",
                 "file": "/a/b/asdf.js",
@@ -2491,7 +2866,7 @@ export const testXliff10 = {
             "comment": "this is a comment"
         }));
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -2540,7 +2915,7 @@ export const testXliff10 = {
             "comment": "this is a comment"
         }));
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -2595,7 +2970,7 @@ export const testXliff10 = {
             "comment": "this is a comment"
         }));
 
-        var units = x.getTranslationUnits();
+        let units = x.getTranslationUnits();
 
         test.ok(units);
 
@@ -2640,7 +3015,7 @@ export const testXliff10 = {
             "comment": "this is a new comment"
         }));
 
-        var units = x.getTranslationUnits();
+        let units = x.getTranslationUnits();
 
         test.ok(units);
 
@@ -2686,7 +3061,7 @@ export const testXliff10 = {
             "comment": "this is a new comment"
         }));
 
-        var units = x.getTranslationUnits();
+        let units = x.getTranslationUnits();
 
         test.ok(units);
 
@@ -2730,7 +3105,7 @@ export const testXliff10 = {
             "datatype": "javascript"
         }));
 
-        var resources = x.getResources();
+        let resources = x.getResources();
 
         test.ok(resources);
 
@@ -2780,7 +3155,7 @@ export const testXliff10 = {
             "flavor": "chocolate"
         }));
 
-        var resources = x.getResources();
+        let resources = x.getResources();
 
         test.ok(resources);
 
@@ -2826,7 +3201,7 @@ export const testXliff10 = {
             "comment": "this is a comment"
         }));
 
-        var units = x.getTranslationUnits();
+        let units = x.getTranslationUnits();
 
         test.ok(units);
 
@@ -2874,7 +3249,7 @@ export const testXliff10 = {
             "datatype": "x-xib"
         }));
 
-        var resources = x.getResources();
+        let resources = x.getResources();
 
         test.ok(resources);
 
@@ -2922,7 +3297,7 @@ export const testXliff10 = {
             "datatype": "x-xib"
         }));
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -3066,8 +3441,8 @@ export const testXliff10 = {
             "comment": "this is a comment"
         }));
 
-        var actual = x.serialize();
-        var expected =
+        let actual = x.serialize();
+        let expected =
                 '<?xml version="1.0" encoding="utf-8"?>\n' +
                 '<xliff version="1.2">\n' +
                 '  <file original="/a/b/asdf.js" source-language="en-US" target-language="de-DE" product-name="iosapp">\n' +
@@ -3104,7 +3479,7 @@ export const testXliff10 = {
         });
         test.ok(x);
 
-        var res = new ResourceString({
+        let res = new ResourceString({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             key: "foobar",
@@ -3112,7 +3487,7 @@ export const testXliff10 = {
             project: "webapp"
         });
 
-        var res2 = new ResourceString({
+        let res2 = new ResourceString({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             key: "foobar",
@@ -3124,7 +3499,7 @@ export const testXliff10 = {
 
         x.addResource(res);
 
-        var reslist = x.getResources({
+        let reslist = x.getResources({
             reskey: "foobar"
         });
 
@@ -3149,7 +3524,7 @@ export const testXliff10 = {
         });
         test.ok(x);
 
-        var res = new ResourceString({
+        let res = new ResourceString({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             key: "foobar",
@@ -3172,7 +3547,7 @@ export const testXliff10 = {
 
         x.addResource(res);
 
-        var reslist = x.getResources({
+        let reslist = x.getResources({
             reskey: "foobar"
         });
 
@@ -3186,7 +3561,7 @@ export const testXliff10 = {
         test.equal(reslist[0].getProject(), "webapp");
         test.ok(!reslist[0].getComment());
 
-        var instances = reslist[0].getInstances();
+        let instances = reslist[0].getInstances();
         test.ok(instances);
         test.equal(instances.length, 1);
 
@@ -3208,7 +3583,7 @@ export const testXliff10 = {
         });
         test.ok(x);
 
-        var res = new ResourceString({
+        let res = new ResourceString({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             key: "foobar",
@@ -3231,7 +3606,7 @@ export const testXliff10 = {
 
         x.addResource(res);
 
-        var expected =
+        let expected =
             '<?xml version="1.0" encoding="utf-8"?>\n' +
             '<xliff version="1.2">\n' +
             '  <file original="foo/bar/asdf.java" source-language="en-US" product-name="webapp">\n' +
@@ -3247,7 +3622,7 @@ export const testXliff10 = {
             '  </file>\n' +
             '</xliff>';
 
-        var actual = x.serialize();
+        let actual = x.serialize();
         diff(actual, expected);
 
         test.equal(actual, expected);
@@ -3293,7 +3668,7 @@ export const testXliff10 = {
             "comment": "this is a different comment"
         }));
 
-        var expected =
+        let expected =
             '<?xml version="1.0" encoding="utf-8"?>\n' +
             '<xliff version="1.2">\n' +
             '  <file original="/a/b/asdf.js" source-language="en-US" target-language="fr-FR" product-name="iosapp">\n' +
@@ -3312,7 +3687,7 @@ export const testXliff10 = {
             '  </file>\n' +
             '</xliff>';
 
-        var actual = x.serialize();
+        let actual = x.serialize();
         diff(actual, expected);
 
         test.equal(actual, expected);
@@ -3347,7 +3722,7 @@ export const testXliff10 = {
             '  </file>\n' +
             '</xliff>');
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -3362,7 +3737,7 @@ export const testXliff10 = {
         test.equal(reslist[0].context, "asdfasdf");
         test.equal(reslist[0].comment, "this is a comment");
 
-        var instances = reslist[0].getInstances();
+        let instances = reslist[0].getInstances();
         test.ok(instances);
         test.equal(instances.length, 1);
 
@@ -3405,7 +3780,7 @@ export const testXliff10 = {
             '  </file>\n' +
             '</xliff>');
 
-        var reslist = x.getResources();
+        let reslist = x.getResources();
 
         test.ok(reslist);
 
@@ -3420,7 +3795,7 @@ export const testXliff10 = {
         test.equal(reslist[0].context, "asdfasdf");
         test.equal(reslist[0].comment, "this is a comment");
 
-        var instances = reslist[0].getInstances();
+        let instances = reslist[0].getInstances();
         test.ok(instances);
         test.equal(instances.length, 1);
 

--- a/test/testXliff10.js
+++ b/test/testXliff10.js
@@ -489,488 +489,63 @@ export const testXliff10 = {
         test.done();
     },
 
-/*
-    testXliffSize: function(test) {
-        test.expect(3);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        let res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            autoKey: false,
-            state: "new",
-            context: "asdf",
-            comment: "this is a comment",
-            project: "webapp"
-        });
-
-        test.equal(x.size(), 0);
-
-        x.addResource(res);
-
-        test.equal(x.size(), 1);
-
-        test.done();
-    },
-
-    testXliffAddMultipleResources: function(test) {
-        test.expect(8);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        let res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        res = new ResourceString({
-            source: "baby baby",
-            sourceLocale: "en-US",
-            key: "huzzah",
-            pathName: "foo/bar/j.java",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        let reslist = x.getResources({
-            reskey: "foobar"
-        });
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-        test.equal(reslist[0].getSource(), "Asdf asdf");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "webapp");
-
-        test.done();
-    },
-
-    testXliffAddMultipleResourcesRightSize: function(test) {
-        test.expect(3);
-
-        const x = new Xliff();
-        test.ok(x);
-        test.equal(x.size(), 0);
-
-        let res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        res = new ResourceString({
-            source: "baby baby",
-            sourceLocale: "en-US",
-            key: "huzzah",
-            pathName: "foo/bar/j.java",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        test.equal(x.size(), 2);
-
-        test.done();
-    },
-
-    testXliffAddMultipleResourcesOverwrite: function(test) {
-        test.expect(9);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        let res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        // this one has the same source, locale, key, and file
-        // so it should overwrite the one above
-        res = new ResourceString({
-            source: "baby baby",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            comment: "blah blah blah",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        let reslist = x.getResources({
-            reskey: "foobar"
-        });
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-        test.equal(reslist[0].getSource(), "baby baby");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "webapp");
-        test.equal(reslist[0].getComment(), "blah blah blah");
-
-        test.done();
-    },
-
-    testXliffAddMultipleResourcesOverwriteRightSize: function(test) {
-        test.expect(4);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        test.equal(x.size(), 0);
-
-        let res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        test.equal(x.size(), 1);
-
-        // this one has the same source, locale, key, and file
-        // so it should overwrite the one above
-        res = new ResourceString({
-            source: "baby baby",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            comment: "blah blah blah",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        test.equal(x.size(), 1);
-
-        test.done();
-    },
-
-    testXliffAddMultipleResourcesNoOverwrite: function(test) {
-        test.expect(13);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        let res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        // this one has a different locale
-        // so it should not overwrite the one above
-        res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "fr-FR",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            comment: "blah blah blah",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        let reslist = x.getResources({
-            reskey: "foobar"
-        });
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 2);
-
-        test.equal(reslist[0].getSource(), "Asdf asdf");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.ok(!reslist[0].getComment());
-
-        test.equal(reslist[1].getSource(), "Asdf asdf");
-        test.equal(reslist[1].getSourceLocale(), "fr-FR");
-        test.equal(reslist[1].getKey(), "foobar");
-        test.equal(reslist[1].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[1].getComment(), "blah blah blah");
-
-        test.done();
-    },
-
-    testXliffAddResourceDontAddSourceLocaleAsTarget: function(test) {
-        test.expect(2);
-
-        const x = new Xliff({
-            sourceLocale: "en-US"
-        });
-        test.ok(x);
-
-        let res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        // should not add this one
-        res = new ResourceString({
-            source: "baby baby",
-            target: "babes babes",
-            targetLocale: "en-US",
-            key: "huzzah",
-            pathName: "foo/bar/j.java",
-            project: "webapp",
-            origin: "target"
-        });
-
-        x.addResource(res);
-
-        test.equal(x.size(), 1);
-
-        test.done();
-    },
-
-    testXliffGetResourcesMultiple: function(test) {
-        test.expect(11);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        let res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp",
-            origin: "source"
-        });
-
-        x.addResource(res);
-
-        res = new ResourceString({
-            source: "baby baby",
-            sourceLocale: "en-US",
-            key: "huzzah",
-            pathName: "foo/bar/j.java",
-            project: "webapp",
-            origin: "origin"
-        });
-
-        x.addResource(res);
-
-        let reslist = x.getResources({
-            sourceLocale: "en-US"
-        });
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 2);
-
-        test.equal(reslist[0].getSource(), "Asdf asdf");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-
-        test.equal(reslist[1].getSource(), "baby baby");
-        test.equal(reslist[1].getSourceLocale(), "en-US");
-        test.equal(reslist[1].getKey(), "huzzah");
-        test.equal(reslist[1].getPath(), "foo/bar/j.java");
-
-        test.done();
-    },
-
-    testXliffSerializeWithContext: function(test) {
-        test.expect(2);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        let res = new ContextResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            target: "gutver",
-            targetLocale: "nl-NL",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            context: "foobar"
-        });
-
-        x.addResource(res);
-
-        let actual = x.serialize();
-        let expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
-            '<xliff version="1.2">\n' +
-            '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="nl-NL" product-name="androidapp">\n' +
-            '    <body>\n' +
-            '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext" x-context="foobar">\n' +
-            '        <source>Asdf asdf</source>\n' +
-            '        <target>gutver</target>\n' +
-            '      </trans-unit>\n' +
-            '    </body>\n' +
-            '  </file>\n' +
-            '</xliff>';
-
-        diff(actual, expected);
-        test.equal(actual, expected);
-        test.done();
-    },
-
-    testXliffSerializeWithSourceOnly: function(test) {
-        test.expect(2);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        let res = new ContextResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            targetLocale: "de-DE"
-        });
-
-        x.addResource(res);
-
-        res = new ContextResourceString({
-            source: "baby baby",
-            sourceLocale: "en-US",
-            key: "huzzah",
-            pathName: "foo/bar/j.java",
-            project: "webapp",
-            targetLocale: "fr-FR"
-        });
-
-        x.addResource(res);
-
-        let actual = x.serialize();
-        let expected =
-            '<?xml version="1.0" encoding="utf-8"?>\n' +
-            '<xliff version="1.2">\n' +
-            '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
-            '    <body>\n' +
-            '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
-            '        <source>Asdf asdf</source>\n' +
-            '      </trans-unit>\n' +
-            '    </body>\n' +
-            '  </file>\n' +
-            '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
-            '    <body>\n' +
-            '      <trans-unit id="2" resname="huzzah" restype="string" datatype="plaintext">\n' +
-            '        <source>baby baby</source>\n' +
-            '      </trans-unit>\n' +
-            '    </body>\n' +
-            '  </file>\n' +
-            '</xliff>';
-
-        diff(actual, expected);
-        test.equal(actual, expected);
-        test.done();
-    },
-
-    testXliffSerializeWithFlavors: function(test) {
-        test.expect(2);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        let res = new ContextResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            target: "gutver",
-            targetLocale: "nl-NL",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            origin: "source",
-            flavor: "chocolate"
-        });
-
-        x.addResource(res);
-
-        let actual = x.serialize();
-        let expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
-            '<xliff version="1.2">\n' +
-            '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="nl-NL" product-name="androidapp" x-flavor="chocolate">\n' +
-            '    <body>\n' +
-            '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
-            '        <source>Asdf asdf</source>\n' +
-            '        <target>gutver</target>\n' +
-            '      </trans-unit>\n' +
-            '    </body>\n' +
-            '  </file>\n' +
-            '</xliff>';
-
-        diff(actual, expected);
-        test.equal(actual, expected);
-        test.done();
-    },
-
     testXliffSerializeWithSourceOnlyAndPlurals: function(test) {
         test.expect(2);
 
         const x = new Xliff();
         test.ok(x);
 
-        let res = new ContextResourceString({
+        let tu = new TranslationUnit({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             key: "foobar",
-            pathName: "foo/bar/asdf.java",
+            file: "foo/bar/asdf.java",
+            datatype: "plaintext",
             project: "androidapp",
-            targetLocale: "de-DE"
+            targetLocale: "de-DE",
+            resType: "string"
         });
 
-        x.addResource(res);
+        x.addTranslationUnit(tu);
 
-        res = new ResourcePlural({
-            sourceStrings: {
-                "zero": "0",
-                "one": "1",
-                "few": "few"
-            },
-            sourceLocale: "en-US",
-            key: "huzzah",
-            pathName: "foo/bar/j.java",
-            project: "webapp",
-            targetLocale: "fr-FR"
-        });
-
-        x.addResource(res);
+        x.addTranslationUnits([
+            new TranslationUnit({
+                source: "0",
+                sourceLocale: "en-US",
+                key: "huzzah",
+                file: "foo/bar/j.java",
+                project: "webapp",
+                targetLocale: "fr-FR",
+                datatype: "x-android-resource",
+                quantity: "zero",
+                resType: "plural",
+                comment: '{"pluralForm":"zero","pluralFormOther":"huzzah"}'
+            }),
+            new TranslationUnit({
+                source: "1",
+                sourceLocale: "en-US",
+                key: "huzzah",
+                file: "foo/bar/j.java",
+                project: "webapp",
+                targetLocale: "fr-FR",
+                datatype: "x-android-resource",
+                quantity: "one",
+                resType: "plural",
+                comment: '{"pluralForm":"one","pluralFormOther":"huzzah"}'
+            }),
+            new TranslationUnit({
+                source: "few",
+                sourceLocale: "en-US",
+                key: "huzzah",
+                file: "foo/bar/j.java",
+                project: "webapp",
+                targetLocale: "fr-FR",
+                datatype: "x-android-resource",
+                quantity: "few",
+                resType: "plural",
+                comment: '{"pluralForm":"few","pluralFormOther":"huzzah"}'
+            })
+        ]);
 
         let actual = x.serialize();
         let expected =
@@ -1006,261 +581,6 @@ export const testXliff10 = {
         test.done();
     },
 
-    testXliffSerializeWithSourceOnlyAndArray: function(test) {
-        test.expect(2);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        let res = new ContextResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            targetLocale: "de-DE"
-        });
-
-        x.addResource(res);
-
-        res = new ResourceArray({
-            sourceArray: ["one", "two", "three"],
-            sourceLocale: "en-US",
-            key: "huzzah",
-            pathName: "foo/bar/j.java",
-            project: "webapp",
-            targetLocale: "fr-FR"
-        });
-
-        x.addResource(res);
-
-        let actual = x.serialize();
-        let expected =
-            '<?xml version="1.0" encoding="utf-8"?>\n' +
-            '<xliff version="1.2">\n' +
-            '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
-            '    <body>\n' +
-            '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
-            '        <source>Asdf asdf</source>\n' +
-            '      </trans-unit>\n' +
-            '    </body>\n' +
-            '  </file>\n' +
-            '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
-            '    <body>\n' +
-            '      <trans-unit id="2" resname="huzzah" restype="array" datatype="x-android-resource" extype="0">\n' +
-            '        <source>one</source>\n' +
-            '      </trans-unit>\n' +
-            '      <trans-unit id="3" resname="huzzah" restype="array" datatype="x-android-resource" extype="1">\n' +
-            '        <source>two</source>\n' +
-            '      </trans-unit>\n' +
-            '      <trans-unit id="4" resname="huzzah" restype="array" datatype="x-android-resource" extype="2">\n' +
-            '        <source>three</source>\n' +
-            '      </trans-unit>\n' +
-            '    </body>\n' +
-            '  </file>\n' +
-            '</xliff>';
-
-        diff(actual, expected);
-        test.equal(actual, expected);
-        test.done();
-    },
-
-    testXliffSerializeWithExplicitIds: function(test) {
-        test.expect(2);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            target: "baby baby",
-            targetLocale: "nl-NL",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            origin: "target",
-            id: 4444444
-        });
-
-        x.addResource(res);
-
-        res = new ResourceString({
-            source: "abcdef",
-            sourceLocale: "en-US",
-            target: "hijklmn",
-            targetLocale: "nl-NL",
-            key: "asdf",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            origin: "target"
-        });
-
-        x.addResource(res);
-
-        let actual = x.serialize();
-        let expected =
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="nl-NL" product-name="androidapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="4444444" resname="foobar" restype="string" datatype="plaintext">\n' +
-                '        <source>Asdf asdf</source>\n' +
-                '        <target>baby baby</target>\n' +
-                '      </trans-unit>\n' +
-                '      <trans-unit id="4444445" resname="asdf" restype="string" datatype="plaintext">\n' +
-                '        <source>abcdef</source>\n' +
-                '        <target>hijklmn</target>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>';
-        diff(actual, expected);
-        test.equal(actual, expected);
-
-        test.done();
-    },
-
-    testXliffSerializeWithSourceAndTarget: function(test) {
-        test.expect(2);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        let res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            target: "foobarfoo",
-            targetLocale: "de-DE",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp",
-            origin: "target"
-        });
-
-        x.addResource(res);
-
-        res = new ResourceString({
-            source: "baby baby",
-            sourceLocale: "en-US",
-            target: "bebe bebe",
-            targetLocale: "fr-FR",
-            key: "huzzah",
-            pathName: "foo/bar/j.java",
-            project: "webapp",
-            origin: "target"
-        });
-
-        x.addResource(res);
-
-        diff(x.serialize(),
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="webapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
-                '        <source>Asdf asdf</source>\n' +
-                '        <target>foobarfoo</target>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="2" resname="huzzah" restype="string" datatype="plaintext">\n' +
-                '        <source>baby baby</source>\n' +
-                '        <target>bebe bebe</target>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        test.equal(x.serialize(),
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="webapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
-                '        <source>Asdf asdf</source>\n' +
-                '        <target>foobarfoo</target>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="2" resname="huzzah" restype="string" datatype="plaintext">\n' +
-                '        <source>baby baby</source>\n' +
-                '        <target>bebe bebe</target>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        test.done();
-    },
-
-    testXliffSerializeWithSourceAndTargetAndComment: function(test) {
-        test.expect(2);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        let res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            target: "foobarfoo",
-            targetLocale: "de-DE",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp",
-            comment: "foobar is where it's at!"
-        });
-
-        x.addResource(res);
-
-        res = new ResourceString({
-            source: "baby baby",
-            sourceLocale: "en-US",
-            target: "bebe bebe",
-            targetLocale: "fr-FR",
-            key: "huzzah",
-            pathName: "foo/bar/j.java",
-            project: "webapp",
-            comment: "come & enjoy it with us"
-        });
-
-        x.addResource(res);
-
-        let expected =
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="webapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
-                '        <source>Asdf asdf</source>\n' +
-                '        <target>foobarfoo</target>\n' +
-                '        <note>foobar is where it\'s at!</note>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="2" resname="huzzah" restype="string" datatype="plaintext">\n' +
-                '        <source>baby baby</source>\n' +
-                '        <target>bebe bebe</target>\n' +
-                '        <note>come &amp; enjoy it with us</note>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>';
-
-        let actual = x.serialize();
-
-        diff(actual, expected);
-        test.equal(actual, expected);
-
-        test.done();
-    },
-
     testXliffSerializeWithHeader: function(test) {
         test.expect(2);
 
@@ -1274,18 +594,19 @@ export const testXliff10 = {
         });
         test.ok(x);
 
-        res = new ResourceString({
+        const tu = new TranslationUnit({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             target: "baby baby",
             targetLocale: "nl-NL",
             key: "foobar",
-            pathName: "foo/bar/asdf.java",
+            file: "foo/bar/asdf.java",
+            datatype: "plaintext",
             project: "webapp",
             origin: "target"
         });
 
-        x.addResource(res);
+        x.addTranslationUnit(tu);
 
         let actual = x.serialize();
         let expected =
@@ -1309,196 +630,36 @@ export const testXliff10 = {
         test.done();
     },
 
-    testXliffSerializeWithPlurals: function(test) {
-        test.expect(2);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        res = new ResourcePlural({
-            sourceStrings: {
-                "one": "There is 1 object.",
-                "other": "There are {n} objects."
-            },
-            sourceLocale: "en-US",
-            targetStrings: {
-                "one": "Da gibts 1 Objekt.",
-                "other": "Da gibts {n} Objekten."
-            },
-            targetLocale: "de-DE",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            resType: "plural",
-            origin: "target",
-            autoKey: true,
-            state: "new",
-            datatype: "ruby"
-        });
-
-        x.addResource(res);
-
-        let actual = x.serialize();
-        let expected =
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="1" resname="foobar" restype="plural" datatype="ruby" extype="one">\n' +
-                '        <source>There is 1 object.</source>\n' +
-                '        <target state="new">Da gibts 1 Objekt.</target>\n' +
-                '        <note>{"pluralForm":"one","pluralFormOther":"foobar"}</note>\n' +
-                '      </trans-unit>\n' +
-                '      <trans-unit id="2" resname="foobar" restype="plural" datatype="ruby" extype="other">\n' +
-                '        <source>There are {n} objects.</source>\n' +
-                '        <target state="new">Da gibts {n} Objekten.</target>\n' +
-                '        <note>{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>';
-        diff(actual, expected);
-        test.equal(actual, expected);
-
-        test.done();
-    },
-
-    testXliffSerializeWithPluralsToLangWithMorePluralsThanEnglish: function(test) {
-        test.expect(2);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        res = new ResourcePlural({
-            sourceStrings: {
-                "one": "There is 1 object.",
-                "other": "There are {n} objects."
-            },
-            sourceLocale: "en-US",
-            targetStrings: {
-                "one": "Имеется {n} объект.",
-                "few": "Есть {n} объекта.",
-                "other": "Всего {n} объектов."
-            },
-            targetLocale: "ru-RU",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            resType: "plural",
-            origin: "target",
-            autoKey: true,
-            state: "new",
-            datatype: "ruby"
-        });
-
-        x.addResource(res);
-
-        let actual = x.serialize();
-        let expected =
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="ru-RU" product-name="androidapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="1" resname="foobar" restype="plural" datatype="ruby" extype="one">\n' +
-                '        <source>There is 1 object.</source>\n' +
-                '        <target state="new">Имеется {n} объект.</target>\n' +
-                '        <note>{"pluralForm":"one","pluralFormOther":"foobar"}</note>\n' +
-                '      </trans-unit>\n' +
-                '      <trans-unit id="2" resname="foobar" restype="plural" datatype="ruby" extype="few">\n' +
-                '        <source>There are {n} objects.</source>\n' +
-                '        <target state="new">Есть {n} объекта.</target>\n' +
-                '        <note>{"pluralForm":"few","pluralFormOther":"foobar"}</note>\n' +
-                '      </trans-unit>\n' +
-                '      <trans-unit id="3" resname="foobar" restype="plural" datatype="ruby" extype="other">\n' +
-                '        <source>There are {n} objects.</source>\n' +
-                '        <target state="new">Всего {n} объектов.</target>\n' +
-                '        <note>{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>';
-        diff(actual, expected);
-        test.equal(actual, expected);
-
-        test.done();
-    },
-
-    testXliffSerializeWithArrays: function(test) {
-        test.expect(2);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        res = new ResourceArray({
-            sourceArray: ["Zero", "One", "Two"],
-            sourceLocale: "en-US",
-            targetArray: ["Zero", "Eins", "Zwei"],
-            targetLocale: "de-DE",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            origin: "target"
-        });
-
-        x.addResource(res);
-
-        let actual = x.serialize();
-        let expected =
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="1" resname="foobar" restype="array" datatype="x-android-resource" extype="0">\n' +
-                '        <source>Zero</source>\n' +
-                '        <target>Zero</target>\n' +
-                '      </trans-unit>\n' +
-                '      <trans-unit id="2" resname="foobar" restype="array" datatype="x-android-resource" extype="1">\n' +
-                '        <source>One</source>\n' +
-                '        <target>Eins</target>\n' +
-                '      </trans-unit>\n' +
-                '      <trans-unit id="3" resname="foobar" restype="array" datatype="x-android-resource" extype="2">\n' +
-                '        <source>Two</source>\n' +
-                '        <target>Zwei</target>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>';
-        diff(actual, expected)
-        test.equal(actual, expected);
-        test.done();
-    },
-
     testXliffSerializeWithXMLEscaping: function(test) {
         test.expect(2);
 
         const x = new Xliff();
         test.ok(x);
 
-        let res = new ResourceString({
-            source: "Asdf <b>asdf</b>",
-            sourceLocale: "en-US",
-            target: "Asdf 'quotes'",
-            targetLocale: "de-DE",
-            key: 'foobar "asdf"',
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            origin: "target"
-        });
-
-        x.addResource(res);
-
-        res = new ResourceString({
-            source: "baby &lt;b&gt;baby&lt;/b&gt;",
-            sourceLocale: "en-US",
-            target: "baby #(test)",
-            targetLocale: "de-DE",
-            key: "huzzah &quot;asdf&quot; #(test)",
-            pathName: "foo/bar/j.java",
-            project: "webapp",
-            origin: "target"
-        });
-
-        x.addResource(res);
+        x.addTranslationUnits([
+            new TranslationUnit({
+                source: "Asdf <b>asdf</b>",
+                sourceLocale: "en-US",
+                target: "Asdf 'quotes'",
+                targetLocale: "de-DE",
+                key: 'foobar "asdf"',
+                file: "foo/bar/asdf.java",
+                project: "androidapp",
+                origin: "target",
+                datatype: "plaintext"
+            }),
+            new TranslationUnit({
+                source: "baby &lt;b&gt;baby&lt;/b&gt;",
+                sourceLocale: "en-US",
+                target: "baby #(test)",
+                targetLocale: "de-DE",
+                key: "huzzah &quot;asdf&quot; #(test)",
+                file: "foo/bar/j.java",
+                project: "webapp",
+                origin: "target",
+                datatype: "plaintext"
+            })
+        ]);
 
         let actual = x.serialize();
         let expected =
@@ -1533,31 +694,30 @@ export const testXliff10 = {
         const x = new Xliff();
         test.ok(x);
 
-        let res = new ResourceString({
-            source: "Asdf <b>asdf</b>",
-            sourceLocale: "en-US",
-            target: "Asdf 'quotes'",
-            targetLocale: "de-DE",
-            key: 'foobar <i>asdf</i>',
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            origin: "target"
-        });
-
-        x.addResource(res);
-
-        res = new ResourceString({
-            source: "baby &lt;b&gt;baby&lt;/b&gt;",
-            sourceLocale: "en-US",
-            target: "baby #(test)",
-            targetLocale: "de-DE",
-            key: "huzzah <b>asdf</b> #(test)",
-            pathName: "foo/bar/j.java",
-            project: "webapp",
-            origin: "target"
-        });
-
-        x.addResource(res);
+        x.addTranslationUnits([
+            new TranslationUnit({
+                source: "Asdf <b>asdf</b>",
+                sourceLocale: "en-US",
+                target: "Asdf 'quotes'",
+                targetLocale: "de-DE",
+                key: 'foobar <i>asdf</i>',
+                file: "foo/bar/asdf.java",
+                project: "androidapp",
+                origin: "target",
+                datatype: "plaintext"
+            }),
+            new TranslationUnit({
+                source: "baby &lt;b&gt;baby&lt;/b&gt;",
+                sourceLocale: "en-US",
+                target: "baby #(test)",
+                targetLocale: "de-DE",
+                key: "huzzah <b>asdf</b> #(test)",
+                file: "foo/bar/j.java",
+                project: "webapp",
+                origin: "target",
+                datatype: "plaintext"
+            })
+        ]);
 
         let actual = x.serialize();
         let expected =
@@ -1592,18 +752,19 @@ export const testXliff10 = {
         const x = new Xliff();
         test.ok(x);
 
-        let res = new ResourceString({
+        const tu = new TranslationUnit({
             source: "Here are \"double\" and 'single' quotes.",
             sourceLocale: "en-US",
             target: "Hier zijn \"dubbel\" en 'singel' quotaties.",
             targetLocale: "nl-NL",
             key: '"double" and \'single\'',
-            pathName: "foo/bar/asdf.java",
+            file: "foo/bar/asdf.java",
             project: "androidapp",
-            origin: "target"
+            origin: "target",
+            datatype: "plaintext"
         });
 
-        x.addResource(res);
+        x.addTranslationUnit(tu);
 
         test.equal(x.serialize(),
                 '<?xml version="1.0" encoding="utf-8"?>\n' +
@@ -1627,31 +788,30 @@ export const testXliff10 = {
         const x = new Xliff();
         test.ok(x);
 
-        let res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            target: "Asdf translated",
-            targetLocale: "de-DE",
-            key: 'asdf \\n\\nasdf',
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            origin: "target"
-        });
-
-        x.addResource(res);
-
-        res = new ResourceString({
-            source: "asdf \\t\\n\\n asdf\\n",
-            sourceLocale: "en-US",
-            target: "fdsa \\t\\n\\n fdsa\\n",
-            targetLocale: "de-DE",
-            key: "asdf \\t\\n\\n asdf\\n",
-            pathName: "foo/bar/j.java",
-            project: "webapp",
-            origin: "target"
-        });
-
-        x.addResource(res);
+        x.addTranslationUnits([
+            new TranslationUnit({
+                source: "Asdf asdf",
+                sourceLocale: "en-US",
+                target: "Asdf translated",
+                targetLocale: "de-DE",
+                key: 'asdf \\n\\nasdf',
+                file: "foo/bar/asdf.java",
+                project: "androidapp",
+                origin: "target",
+                datatype: "plaintext"
+            }),
+            new TranslationUnit({
+                source: "asdf \\t\\n\\n asdf\\n",
+                sourceLocale: "en-US",
+                target: "fdsa \\t\\n\\n fdsa\\n",
+                targetLocale: "de-DE",
+                key: "asdf \\t\\n\\n asdf\\n",
+                file: "foo/bar/j.java",
+                project: "webapp",
+                origin: "target",
+                datatype: "plaintext"
+            })
+        ]);
 
         let actual = x.serialize();
         let expected =
@@ -1677,1731 +837,6 @@ export const testXliff10 = {
 
         diff(actual, expected);
         test.equal(actual, expected);
-        test.done();
-    },
-
-    testXliffSerializeWithComments: function(test) {
-        test.expect(2);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            target: "baby baby",
-            targetLocale: "nl-NL",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            comment: "A very nice string",
-            origin: "target"
-        });
-
-        x.addResource(res);
-
-        test.equal(x.serialize(),
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="nl-NL" product-name="androidapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
-                '        <source>Asdf asdf</source>\n' +
-                '        <target>baby baby</target>\n' +
-                '        <note>A very nice string</note>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        test.done();
-    },
-
-    testXliffDeserializeWithSourceOnly: function(test) {
-        test.expect(21);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
-                '        <source>Asdf asdf</source>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="2" resname="huzzah" restype="string" datatype="plaintext">\n' +
-                '        <source>baby baby</source>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        let reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 2);
-
-        test.equal(reslist[0].getSource(), "Asdf asdf");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.ok(!reslist[0].getTarget());
-        test.equal(reslist[0].getTargetLocale(), "de-DE");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), "1");
-
-        test.equal(reslist[1].getSource(), "baby baby");
-        test.equal(reslist[1].getSourceLocale(), "en-US");
-        test.ok(!reslist[1].getTarget());
-        test.equal(reslist[1].getTargetLocale(), "fr-FR");
-        test.equal(reslist[1].getKey(), "huzzah");
-        test.equal(reslist[1].getPath(), "foo/bar/j.java");
-        test.equal(reslist[1].getProject(), "webapp");
-        test.equal(reslist[1].resType, "string");
-        test.equal(reslist[1].getId(), "2");
-
-        test.done();
-    },
-
-    testXliffDeserializeWithSourceAndTarget: function(test) {
-        test.expect(21);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="1" resname="foobar" restype="string">\n' +
-                '        <source>Asdf asdf</source>\n' +
-                '        <target>foobarfoo</target>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
-                '        <source>baby baby</source>\n' +
-                '        <target>bebe bebe</target>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        // console.log("x is " + JSON.stringify(x, undefined, 4));
-        let reslist = x.getResources();
-        // console.log("x is now " + JSON.stringify(x, undefined, 4));
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 2);
-
-        test.equal(reslist[0].getSource(), "Asdf asdf");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), "1");
-        test.equal(reslist[0].getTarget(), "foobarfoo");
-        test.equal(reslist[0].getTargetLocale(), "de-DE");
-
-        test.equal(reslist[1].getSource(), "baby baby");
-        test.equal(reslist[1].getSourceLocale(), "en-US");
-        test.equal(reslist[1].getKey(), "huzzah");
-        test.equal(reslist[1].getPath(), "foo/bar/j.java");
-        test.equal(reslist[1].getProject(), "webapp");
-        test.equal(reslist[1].resType, "string");
-        test.equal(reslist[1].getId(), "2");
-        test.equal(reslist[1].getTarget(), "bebe bebe");
-        test.equal(reslist[1].getTargetLocale(), "fr-FR");
-
-        test.done();
-    },
-
-    testXliffDeserializeWithXMLUnescaping: function(test) {
-        test.expect(19);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/asdf.java" source-language="en-US" product-name="androidapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="1" resname="foobar" restype="string">\n' +
-                '        <source>Asdf &lt;b&gt;asdf&lt;/b&gt;</source>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" source-language="en-US" product-name="webapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
-                '        <source>baby &amp;lt;b&amp;gt;baby&amp;lt;/b&amp;gt;</source>\n' +   // double escaped!
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        let reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 2);
-
-        test.equal(reslist[0].getSource(), "Asdf <b>asdf</b>");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), "1");
-        test.ok(!reslist[0].getTarget());
-
-        test.equal(reslist[1].getSource(), "baby &lt;b&gt;baby&lt;/b&gt;");
-        test.equal(reslist[1].getSourceLocale(), "en-US");
-        test.equal(reslist[1].getKey(), "huzzah");
-        test.equal(reslist[1].getPath(), "foo/bar/j.java");
-        test.equal(reslist[1].getProject(), "webapp");
-        test.equal(reslist[1].resType, "string");
-        test.equal(reslist[1].getId(), "2");
-        test.ok(!reslist[1].getTarget());
-
-        test.done();
-    },
-
-    testXliffDeserializeWithXMLUnescapingInResname: function(test) {
-        test.expect(19);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/asdf.java" source-language="en-US" product-name="androidapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="1" resname="foobar &lt;a>link&lt;/a>" restype="string">\n' +
-                '        <source>Asdf &lt;b&gt;asdf&lt;/b&gt;</source>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" source-language="en-US" product-name="webapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="2" resname="&lt;b>huzzah&lt;/b>" restype="string">\n' +
-                '        <source>baby &amp;lt;b&amp;gt;baby&amp;lt;/b&amp;gt;</source>\n' +   // double escaped!
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        let reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 2);
-
-        test.equal(reslist[0].getSource(), "Asdf <b>asdf</b>");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar <a>link</a>");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), "1");
-        test.ok(!reslist[0].getTarget());
-
-        test.equal(reslist[1].getSource(), "baby &lt;b&gt;baby&lt;/b&gt;");
-        test.equal(reslist[1].getSourceLocale(), "en-US");
-        test.equal(reslist[1].getKey(), "<b>huzzah</b>");
-        test.equal(reslist[1].getPath(), "foo/bar/j.java");
-        test.equal(reslist[1].getProject(), "webapp");
-        test.equal(reslist[1].resType, "string");
-        test.equal(reslist[1].getId(), "2");
-        test.ok(!reslist[1].getTarget());
-
-        test.done();
-    },
-
-    testXliffDeserializeWithEscapedNewLines: function(test) {
-        test.expect(17);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="en-CA" product-name="androidapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="1" resname="foobar" restype="string">\n' +
-                '        <source>a\\nb</source>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" source-language="en-US" target-language="en-CA" product-name="webapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
-                '        <source>e\\nh</source>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        let reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 2);
-
-        test.equal(reslist[0].getSource(), "a\\nb");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), "1");
-
-        test.equal(reslist[1].getSource(), "e\\nh");
-        test.equal(reslist[1].getSourceLocale(), "en-US");
-        test.equal(reslist[1].getKey(), "huzzah");
-        test.equal(reslist[1].getPath(), "foo/bar/j.java");
-        test.equal(reslist[1].getProject(), "webapp");
-        test.equal(reslist[1].resType, "string");
-        test.equal(reslist[1].getId(), "2");
-
-        test.done();
-    },
-
-    testXliffDeserializeWithEscapedNewLinesInResname: function(test) {
-        test.expect(17);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="en-CA" product-name="androidapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="1" resname="foobar\\n\\nasdf" restype="string">\n' +
-                '        <source>a\\nb</source>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" source-language="en-US" target-language="en-CA" product-name="webapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="2" resname="huzzah\\t\\n" restype="string">\n' +
-                '        <source>e\\nh</source>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        let reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 2);
-
-        test.equal(reslist[0].getSource(), "a\\nb");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar\\n\\nasdf");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), "1");
-
-        test.equal(reslist[1].getSource(), "e\\nh");
-        test.equal(reslist[1].getSourceLocale(), "en-US");
-        test.equal(reslist[1].getKey(), "huzzah\\t\\n");
-        test.equal(reslist[1].getPath(), "foo/bar/j.java");
-        test.equal(reslist[1].getProject(), "webapp");
-        test.equal(reslist[1].resType, "string");
-        test.equal(reslist[1].getId(), "2");
-
-        test.done();
-    },
-
-    testXliffDeserializeWithPlurals: function(test) {
-        test.expect(10);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/asdf.java" source-language="en-US" product-name="androidapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="1" resname="foobar" restype="plural" datatype="x-android-resource" extype="one">\n' +
-                '        <source>There is 1 object.</source>\n' +
-                '      </trans-unit>\n' +
-                '      <trans-unit id="2" resname="foobar" restype="plural" datatype="x-android-resource" extype="other">\n' +
-                '        <source>There are {n} objects.</source>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        // console.log("x is " + JSON.stringify(x, undefined, 4));
-
-        let reslist = x.getResources();
-
-        // console.log("after get resources x is " + JSON.stringify(x, undefined, 4));
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.deepEqual(reslist[0].getSourcePlurals(), {
-            one: "There is 1 object.",
-            other: "There are {n} objects."
-        });
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "plural");
-        test.equal(reslist[0].getId(), "1");
-
-        test.done();
-    },
-
-    testXliffDeserializeWithPluralsTranslated: function(test) {
-        test.expect(13);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="es-US" product-name="androidapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="1" resname="foobar" restype="plural" datatype="x-android-resource" extype="one">\n' +
-                '        <source>There is 1 object.</source>\n' +
-                '        <target>Hay 1 objeto.</target>\n' +
-                '      </trans-unit>\n' +
-                '      <trans-unit id="2" resname="foobar" restype="plural" datatype="x-android-resource" extype="other">\n' +
-                '        <source>There are {n} objects.</source>\n' +
-                '        <target>Hay {n} objetos.</target>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        // console.log("x is " + JSON.stringify(x, undefined, 4));
-
-        let reslist = x.getResources();
-
-        // console.log("after get resources x is " + JSON.stringify(x, undefined, 4));
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.deepEqual(reslist[0].getSourcePlurals(), {
-            one: "There is 1 object.",
-            other: "There are {n} objects."
-        });
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "plural");
-        test.equal(reslist[0].getId(), "1");
-        test.equal(reslist[0].getOrigin(), "source");
-
-        test.deepEqual(reslist[0].getTargetPlurals(), {
-            one: "Hay 1 objeto.",
-            other: "Hay {n} objetos."
-        });
-        test.equal(reslist[0].getTargetLocale(), "es-US");
-
-        test.done();
-    },
-
-    testXliffDeserializeWithArrays: function(test) {
-        test.expect(10);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="1" resname="foobar" restype="array" datatype="x-android-resource" extype="0">\n' +
-                '        <source>Zero</source>\n' +
-                '      </trans-unit>\n' +
-                '      <trans-unit id="2" resname="foobar" restype="array" datatype="x-android-resource" extype="1">\n' +
-                '        <source>One</source>\n' +
-                '      </trans-unit>\n' +
-                '      <trans-unit id="3" resname="foobar" restype="array" datatype="x-android-resource" extype="2">\n' +
-                '        <source>Two</source>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        let reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.deepEqual(reslist[0].getSourceArray(), ["Zero", "One", "Two"]);
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "array");
-        test.ok(!reslist[0].getTargetArray());
-
-        test.done();
-    },
-
-    testXliffDeserializeWithArraysTranslated: function(test) {
-        test.expect(12);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="1" resname="foobar" restype="array" datatype="x-android-resource" extype="0">\n' +
-                '        <source>Zero</source>\n' +
-                '        <target>Zero</target>\n' +
-                '      </trans-unit>\n' +
-                '      <trans-unit id="2" resname="foobar" restype="array" datatype="x-android-resource" extype="1">\n' +
-                '        <source>One</source>\n' +
-                '        <target>Eins</target>\n' +
-                '      </trans-unit>\n' +
-                '      <trans-unit id="3" resname="foobar" restype="array" datatype="x-android-resource" extype="2">\n' +
-                '        <source>Two</source>\n' +
-                '        <target>Zwei</target>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        let reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.deepEqual(reslist[0].getSourceArray(), ["Zero", "One", "Two"]);
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "array");
-        test.equal(reslist[0].getOrigin(), "source");
-        test.deepEqual(reslist[0].getTargetArray(), ["Zero", "Eins", "Zwei"]);
-        test.equal(reslist[0].getTargetLocale(), "de-DE");
-
-        test.done();
-    },
-
-    testXliffDeserializeWithArraysAndTranslations: function(test) {
-        test.expect(20);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="res/values/arrays.xml" source-language="en-US" target-language="es-US" product-name="androidapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="2" resname="huzzah" restype="array" datatype="x-android-resource" extype="0">\n' +
-                '        <source>This is element 0</source>\n' +
-                '        <target>Este es 0</target>\n' +
-                '      </trans-unit>\n' +
-                '      <trans-unit id="3" resname="huzzah" restype="array" datatype="x-android-resource" extype="1">\n' +
-                '        <source>This is element 1</source>\n' +
-                '        <target>Este es 1</target>\n' +
-                '      </trans-unit>\n' +
-                '      <trans-unit id="4" resname="huzzah" restype="array" datatype="x-android-resource" extype="2">\n' +
-                '        <source>This is element 2</source>\n' +
-                '        <target>Este es 2</target>\n' +
-                '      </trans-unit>\n' +
-                '      <trans-unit id="5" resname="huzzah" restype="array" datatype="x-android-resource" extype="3">\n' +
-                '        <source>This is element 3</source>\n' +
-                '        <target>Este es 3</target>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        let reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getTargetLocale(), "es-US");
-        test.equal(reslist[0].getKey(), "huzzah");
-        test.equal(reslist[0].getPath(), "res/values/arrays.xml");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "array");
-        test.equal(reslist[0].getOrigin(), "source");
-
-        let items = reslist[0].getSourceArray();
-
-        test.equal(items.length, 4);
-        test.equal(items[0], "This is element 0");
-        test.equal(items[1], "This is element 1");
-        test.equal(items[2], "This is element 2");
-        test.equal(items[3], "This is element 3");
-
-        items = reslist[0].getTargetArray();
-
-        test.equal(items.length, 4);
-        test.equal(items[0], "Este es 0");
-        test.equal(items[1], "Este es 1");
-        test.equal(items[2], "Este es 2");
-        test.equal(items[3], "Este es 3");
-
-        test.done();
-    },
-
-    testXliffDeserializeWithArraysAndTranslationsPartial: function(test) {
-        test.expect(20);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="res/values/arrays.xml" source-language="en-US" target-language="es-US" product-name="androidapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="5" resname="huzzah" restype="array" datatype="x-android-resource" extype="3">\n' +
-                '        <source>This is element 3</source>\n' +
-                '        <target>Este es 3</target>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        let reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getTargetLocale(), "es-US");
-        test.equal(reslist[0].getKey(), "huzzah");
-        test.equal(reslist[0].getPath(), "res/values/arrays.xml");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "array");
-        test.equal(reslist[0].getOrigin(), "source");
-
-        let items = reslist[0].getSourceArray();
-
-        test.equal(items.length, 4);
-        test.equal(items[0], null);
-        test.equal(items[1], null);
-        test.equal(items[2], null);
-        test.equal(items[3], "This is element 3");
-
-        items = reslist[0].getTargetArray();
-
-        test.equal(items.length, 4);
-        test.equal(items[0], null);
-        test.equal(items[1], null);
-        test.equal(items[2], null);
-        test.equal(items[3], "Este es 3");
-
-        test.done();
-    },
-
-    testXliffDeserializeWithComments: function(test) {
-        test.expect(18);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/asdf.java" source-language="en-US" product-name="androidapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="1" resname="foobar" restype="string">\n' +
-                '        <source>Asdf asdf</source>\n' +
-                '        <note>A very nice string</note>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" source-language="en-US" product-name="webapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
-                '        <source>baby baby</source>\n' +
-                '        <note>Totally awesome.</note>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        let reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist[0].getSource(), "Asdf asdf");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getComment(), "A very nice string");
-        test.equal(reslist[0].getId(), "1");
-
-        test.equal(reslist[1].getSource(), "baby baby");
-        test.equal(reslist[1].getSourceLocale(), "en-US");
-        test.equal(reslist[1].getKey(), "huzzah");
-        test.equal(reslist[1].getPath(), "foo/bar/j.java");
-        test.equal(reslist[1].getProject(), "webapp");
-        test.equal(reslist[1].resType, "string");
-        test.equal(reslist[1].getComment(), "Totally awesome.");
-        test.equal(reslist[1].getId(), "2");
-
-        test.done();
-    },
-
-    testXliffDeserializeWithContext: function(test) {
-        test.expect(19);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="1" resname="foobar" restype="string" x-context="na na na">\n' +
-                '        <source>Asdf asdf</source>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="2" resname="huzzah" restype="string" x-context="asdf">\n' +
-                '        <source>baby baby</source>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        let reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 2);
-
-        test.equal(reslist[0].getSource(), "Asdf asdf");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), "1");
-        test.equal(reslist[0].getContext(), "na na na");
-
-        test.equal(reslist[1].getSource(), "baby baby");
-        test.equal(reslist[1].getSourceLocale(), "en-US");
-        test.equal(reslist[1].getKey(), "huzzah");
-        test.equal(reslist[1].getPath(), "foo/bar/j.java");
-        test.equal(reslist[1].getProject(), "webapp");
-        test.equal(reslist[1].resType, "string");
-        test.equal(reslist[1].getId(), "2");
-        test.equal(reslist[1].getContext(), "asdf");
-
-        test.done();
-    },
-
-    testXliffDeserializeRealFile: function(test) {
-        test.expect(3);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        let fs = require("fs");
-
-        let str = fs.readFileSync("testfiles/test.xliff", "utf-8");
-
-        x.deserialize(str);
-
-        let reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 4);
-
-        test.done();
-    },
-
-    testXliffDeserializeEmptySource: function(test) {
-        test.expect(12);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="1" resname="foobar" restype="string" x-context="na na na">\n' +
-                '        <source></source>\n' +
-                '        <target>Baby Baby</target>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
-                '        <source>baby baby</source>\n' +
-                '        <target>bebe bebe</target>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        let reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.equal(reslist[0].getSource(), "baby baby");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "huzzah");
-        test.equal(reslist[0].getPath(), "foo/bar/j.java");
-        test.equal(reslist[0].getProject(), "webapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), "2");
-
-        test.equal(reslist[0].getTarget(), "bebe bebe");
-        test.equal(reslist[0].getTargetLocale(), "fr-FR");
-
-        test.done();
-    },
-
-    testXliffDeserializeEmptyTarget: function(test) {
-        test.expect(19);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="1" resname="foobar" restype="string">\n' +
-                '        <source>Asdf asdf</source>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
-                '        <source>baby baby</source>\n' +
-                '        <target></target>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        let reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 2);
-
-        test.equal(reslist[0].getSource(), "Asdf asdf");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), "1");
-        test.equal(reslist[0].getOrigin(), "source");
-
-        test.equal(reslist[1].getSource(), "baby baby");
-        test.equal(reslist[1].getSourceLocale(), "en-US");
-        test.equal(reslist[1].getKey(), "huzzah");
-        test.equal(reslist[1].getPath(), "foo/bar/j.java");
-        test.equal(reslist[1].getProject(), "webapp");
-        test.equal(reslist[1].resType, "string");
-        test.equal(reslist[1].getId(), "2");
-        test.equal(reslist[1].getOrigin(), "source");
-
-        test.done();
-    },
-
-    testXliffDeserializeWithMrkTagInTarget: function(test) {
-        test.expect(12);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
-                '        <source>baby baby</source><seg-source><mrk mtype="seg" mid="4">baby baby</mrk></seg-source><target><mrk mtype="seg" mid="4">bebe bebe</mrk></target>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        let reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.equal(reslist[0].getSource(), "baby baby");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "huzzah");
-        test.equal(reslist[0].getPath(), "foo/bar/j.java");
-        test.equal(reslist[0].getProject(), "webapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), "2");
-
-        test.equal(reslist[0].getTarget(), "bebe bebe");
-        test.equal(reslist[0].getTargetLocale(), "fr-FR");
-
-        test.done();
-    },
-
-    testXliffDeserializeWithEmptyMrkTagInTarget: function(test) {
-        test.expect(11);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
-                '        <source>baby baby</source><seg-source><mrk mtype="seg" mid="4">baby baby</mrk></seg-source><target><mrk mtype="seg" mid="4"/></target>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        let reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.equal(reslist[0].getSource(), "baby baby");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "huzzah");
-        test.equal(reslist[0].getPath(), "foo/bar/j.java");
-        test.equal(reslist[0].getProject(), "webapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), "2");
-        test.equal(reslist[0].getOrigin(), "source");
-
-        test.done();
-    },
-
-    testXliffDeserializeWithMultipleMrkTagsInTargetEuro: function(test) {
-        test.expect(12);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
-                '        <source>baby baby</source><seg-source><mrk mtype="seg" mid="4">baby baby</mrk></seg-source><target><mrk mtype="seg" mid="4">This is segment 1.</mrk> <mrk mtype="seg" mid="5">This is segment 2.</mrk> <mrk mtype="seg" mid="6">This is segment 3.</mrk></target>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        let reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.equal(reslist[0].getSource(), "baby baby");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "huzzah");
-        test.equal(reslist[0].getPath(), "foo/bar/j.java");
-        test.equal(reslist[0].getProject(), "webapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), "2");
-
-        test.equal(reslist[0].getTarget(), "This is segment 1. This is segment 2. This is segment 3.");
-        test.equal(reslist[0].getTargetLocale(), "fr-FR");
-
-        test.done();
-    },
-
-    testXliffDeserializeWithMultipleMrkTagsInTargetAsian: function(test) {
-        test.expect(12);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="foo/bar/j.java" source-language="en-US" target-language="zh-Hans-CN" product-name="webapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
-                '        <source>baby baby</source><seg-source><mrk mtype="seg" mid="4">baby baby</mrk></seg-source><target><mrk mtype="seg" mid="4">This is segment 1.</mrk> <mrk mtype="seg" mid="5">This is segment 2.</mrk> <mrk mtype="seg" mid="6">This is segment 3.</mrk></target>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        let reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.equal(reslist[0].getSource(), "baby baby");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "huzzah");
-        test.equal(reslist[0].getPath(), "foo/bar/j.java");
-        test.equal(reslist[0].getProject(), "webapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), "2");
-
-        test.equal(reslist[0].getTarget(), "This is segment 1.This is segment 2.This is segment 3.");
-        test.equal(reslist[0].getTargetLocale(), "zh-Hans-CN");
-
-        test.done();
-    },
-
-    testXliffDeserializePreserveSourceWhitespace: function(test) {
-        test.expect(9);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="UI/AddAnotherButtonView.m" source-language="en-US" target-language="es-US" product-name="iosapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="196" resname="      Add Another" restype="string" datatype="x-objective-c">\n' +
-                '        <source>      Add Another</source>\n' +
-                '        <target>Añadir Otro</target>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        let reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.equal(reslist[0].getSource(), "      Add Another");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "      Add Another");
-        test.equal(reslist[0].getPath(), "UI/AddAnotherButtonView.m");
-        test.equal(reslist[0].getProject(), "iosapp");
-        test.equal(reslist[0].resType, "string");
-
-        test.done();
-    },
-
-    testXliffDeserializePreserveTargetWhitespace: function(test) {
-        test.expect(9);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="UI/AddAnotherButtonView.m" source-language="en-US" target-language="es-US" product-name="iosapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="196" resname="      Add Another" restype="string" datatype="x-objective-c">\n' +
-                '        <source>      Add Another</source>\n' +
-                '        <target> Añadir    Otro  </target>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        let reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.equal(reslist[0].getTarget(), " Añadir    Otro  ");
-        test.equal(reslist[0].getTargetLocale(), "es-US");
-        test.equal(reslist[0].getKey(), "      Add Another");
-        test.equal(reslist[0].getPath(), "UI/AddAnotherButtonView.m");
-        test.equal(reslist[0].getProject(), "iosapp");
-        test.equal(reslist[0].resType, "string");
-
-        test.done();
-    },
-
-
-    testXliffTranslationUnitConstructor: function(test) {
-        test.expect(1);
-
-        let tu = new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp"
-        });
-
-        test.ok(tu);
-
-        test.done();
-    },
-
-    testXliffTranslationUnitConstructorEverythingCopied: function(test) {
-        test.expect(11);
-
-        let tu = new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a comment",
-            "flavor": "chocolate"
-        });
-
-        test.ok(tu);
-
-        test.equal(tu.source, "a");
-        test.equal(tu.sourceLocale, "en-US");
-        test.equal(tu.key, "foobar");
-        test.equal(tu.file, "/a/b/asdf.js");
-        test.equal(tu.project, "iosapp");
-        test.equal(tu.id, 2334);
-        test.equal(tu.origin, "source");
-        test.equal(tu.context, "asdfasdf");
-        test.equal(tu.comment, "this is a comment");
-        test.equal(tu.flavor, "chocolate");
-
-        test.done();
-    },
-
-    testXliffTranslationUnitConstructorMissingBasicProperties: function(test) {
-        test.expect(1);
-
-        test.throws(function() {
-            let tu = new TranslationUnit({
-                "source": "a",
-                "sourceLocale": "en-US",
-                "file": "/a/b/asdf.js",
-                "project": "iosapp",
-                "id": 2334,
-                "origin": "source",
-                "context": "asdfasdf",
-                "comment": "this is a comment"
-            });
-        });
-
-        test.done();
-    },
-
-    testXliffAddTranslationUnit: function(test) {
-        test.expect(10);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        let reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.equal(reslist[0].getSource(), "a");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "/a/b/asdf.js");
-        test.equal(reslist[0].getProject(), "iosapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), 2334);
-
-        test.done();
-    },
-
-    testXliffAddTranslationUnitMergeResources: function(test) {
-        test.expect(12);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "b",
-            "targetLocale": "fr-FR",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        let reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.equal(reslist[0].getSource(), "a");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getTarget(), "b");
-        test.equal(reslist[0].getTargetLocale(), "fr-FR");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "/a/b/asdf.js");
-        test.equal(reslist[0].getProject(), "iosapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), 2334);
-
-        test.done();
-    },
-
-    testXliffAddTranslationUnitAddMultipleUnits: function(test) {
-        test.expect(3);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "bababa",
-            "sourceLocale": "en-US",
-            "target": "ababab",
-            "targetLocale": "fr-FR",
-            "key": "asdf",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2333,
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "b",
-            "targetLocale": "fr-FR",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        let units = x.getTranslationUnits();
-
-        test.ok(units);
-
-        test.equal(units.length, 2);
-
-        test.done();
-    },
-
-    testXliffAddTranslationUnitReplacePreviousUnit: function(test) {
-        test.expect(3);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "b",
-            "targetLocale": "fr-FR",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "ab",
-            "sourceLocale": "en-US",
-            "target": "ba",
-            "targetLocale": "fr-FR",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a new comment"
-        }));
-
-        let units = x.getTranslationUnits();
-
-        test.ok(units);
-
-        // should have merged them into 1 unit because the signature was the same
-        test.equal(units.length, 1);
-
-        test.done();
-    },
-
-    testXliffAddTranslationUnitRightContents: function(test) {
-        test.expect(15);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "b",
-            "targetLocale": "fr-FR",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "ab",
-            "sourceLocale": "en-US",
-            "target": "ba",
-            "targetLocale": "fr-FR",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a new comment"
-        }));
-
-        let units = x.getTranslationUnits();
-
-        test.ok(units);
-
-        test.equal(units.length, 1);
-
-        test.equal(units[0].source, "ab");
-        test.equal(units[0].sourceLocale, "en-US");
-        test.equal(units[0].target, "ba");
-        test.equal(units[0].targetLocale, "fr-FR");
-        test.equal(units[0].key, "foobar");
-        test.equal(units[0].file, "/a/b/asdf.js");
-        test.equal(units[0].project, "iosapp");
-        test.equal(units[0].id, 2334);
-        test.equal(units[0].resType, "string");
-        test.equal(units[0].origin, "source");
-        test.equal(units[0].context, "asdfasdf");
-        test.equal(units[0].comment, "this is a new comment");
-
-        test.done();
-    },
-
-    testXliffAddTranslationUnitRightResourceTypesRegularString: function(test) {
-        test.expect(4);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "b",
-            "targetLocale": "fr-FR",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType": "string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a comment",
-            "datatype": "javascript"
-        }));
-
-        let resources = x.getResources();
-
-        test.ok(resources);
-
-        test.equal(resources.length, 1);
-
-        test.ok(resources[0] instanceof ResourceString);
-
-        test.done();
-    },
-
-    testXliffAddTranslationUnitRightResourceTypesContextString: function(test) {
-        test.expect(5);
-
-        ResourceFactory.registerDataType("x-android-resource", "string", ContextResourceString);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "ba",
-            "targetLocale": "fr-FR",
-            "key": "foobar",
-            "file": "/a/b/asdf.xml",
-            "project": "androidapp",
-            "id": 2334,
-            "resType":"string",
-            "comment": "this is a comment",
-            "datatype": "x-android-resource",
-            "flavor": "chocolate"
-        }));
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "baa",
-            "targetLocale": "fr-FR",
-            "key": "foobar",
-            "file": "/a/b-x/asdf.xml",
-            "project": "androidapp",
-            "id": 2334,
-            "resType": "string",
-            "context": "x",
-            "comment": "this is a new comment",
-            "datatype": "x-android-resource",
-            "flavor": "chocolate"
-        }));
-
-        let resources = x.getResources();
-
-        test.ok(resources);
-
-        test.equal(resources.length, 2);
-
-        test.ok(resources[0] instanceof ContextResourceString);
-        test.ok(resources[1] instanceof ContextResourceString);
-
-        test.done();
-    },
-
-    testXliffAddTranslationUnitReplaceSourceOnlyUnit: function(test) {
-        test.expect(3);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType": "string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "b",
-            "targetLocale": "fr-FR",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        let units = x.getTranslationUnits();
-
-        test.ok(units);
-
-        // should have merged them into 1 unit because the signature was the same
-        test.equal(units.length, 1);
-
-        test.done();
-    },
-
-    testXliffAddTranslationUnitDifferentPathsRightTypes: function(test) {
-        test.expect(5);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        ResourceFactory.registerDataType("x-xib", "string", IosLayoutResourceString);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "foo",
-            "targetLocale": "de-DE",
-            "key": "foobar",
-            "file": "a/b/asdf.xib",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "origin": "target",
-            "comment": "this is a comment",
-            "datatype": "x-xib"
-        }));
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "foo",
-            "targetLocale": "de-DE",
-            "key": "foobar",
-            "file": "a/b/asdf~ipad.xib",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "origin": "target",
-            "comment": "this is a comment",
-            "datatype": "x-xib"
-        }));
-
-        let resources = x.getResources();
-
-        test.ok(resources);
-
-        test.equal(resources.length, 2);
-
-        test.ok(resources[0] instanceof IosLayoutResourceString);
-        test.ok(resources[1] instanceof IosLayoutResourceString);
-
-        test.done();
-    },
-
-    testXliffAddTranslationUnitDifferentPaths: function(test) {
-        test.expect(23);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        ResourceFactory.registerDataType("x-xib", "string", IosLayoutResourceString);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "foo",
-            "targetLocale": "de-DE",
-            "key": "foobar",
-            "file": "a/b/asdf.xib",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "comment": "this is a comment",
-            "datatype": "x-xib"
-        }));
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "foo",
-            "targetLocale": "de-DE",
-            "key": "foobar",
-            "file": "a/b/asdf~ipad.xib",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "comment": "this is a comment",
-            "datatype": "x-xib"
-        }));
-
-        let reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 2);
-
-        test.equal(reslist[0].getSource(), "a");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getTarget(), "foo");
-        test.equal(reslist[0].getTargetLocale(), "de-DE");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "a/b/asdf.xib");
-        test.equal(reslist[0].getProject(), "iosapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].datatype, "x-xib");
-        test.equal(reslist[0].getId(), 2334);
-
-        test.equal(reslist[1].getSource(), "a");
-        test.equal(reslist[1].getSourceLocale(), "en-US");
-        test.equal(reslist[1].getTarget(), "foo");
-        test.equal(reslist[1].getTargetLocale(), "de-DE");
-        test.equal(reslist[1].getKey(), "foobar");
-        test.equal(reslist[1].getPath(), "a/b/asdf~ipad.xib");
-        test.equal(reslist[1].getProject(), "iosapp");
-        test.equal(reslist[1].resType, "string");
-        test.equal(reslist[1].datatype, "x-xib");
-        test.equal(reslist[1].getId(), 2334);
-
-        test.done();
-    },
-
-    testXliffSerializeWithTranslationUnits: function(test) {
-        test.expect(2);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "bababa",
-            "sourceLocale": "en-US",
-            "target": "ababab",
-            "targetLocale": "fr-FR",
-            "key": "asdf",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2333,
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "b",
-            "targetLocale": "fr-FR",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        diff(x.serialize(),
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="/a/b/asdf.js" source-language="en-US" target-language="fr-FR" product-name="iosapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="2333" resname="asdf" restype="string" x-context="asdfasdf">\n' +
-                '        <source>bababa</source>\n' +
-                '        <target>ababab</target>\n' +
-                '        <note>this is a comment</note>\n' +
-                '      </trans-unit>\n' +
-                '      <trans-unit id="2334" resname="foobar" restype="string" x-context="asdfasdf">\n' +
-                '        <source>a</source>\n' +
-                '        <target>b</target>\n' +
-                '        <note>this is a comment</note>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        test.equal(x.serialize(),
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="1.2">\n' +
-                '  <file original="/a/b/asdf.js" source-language="en-US" target-language="fr-FR" product-name="iosapp">\n' +
-                '    <body>\n' +
-                '      <trans-unit id="2333" resname="asdf" restype="string" x-context="asdfasdf">\n' +
-                '        <source>bababa</source>\n' +
-                '        <target>ababab</target>\n' +
-                '        <note>this is a comment</note>\n' +
-                '      </trans-unit>\n' +
-                '      <trans-unit id="2334" resname="foobar" restype="string" x-context="asdfasdf">\n' +
-                '        <source>a</source>\n' +
-                '        <target>b</target>\n' +
-                '        <note>this is a comment</note>\n' +
-                '      </trans-unit>\n' +
-                '    </body>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
         test.done();
     },
 
@@ -3471,290 +906,693 @@ export const testXliff10 = {
         test.done();
     },
 
-    testXliffAddResourcesWithInstances: function(test) {
-        test.expect(9);
-
-        const x = new Xliff({
-            allowDups: true
-        });
-        test.ok(x);
-
-        let res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp"
-        });
-
-        let res2 = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp",
-            comment: "special translators note"
-        });
-        res.addInstance(res2);
-
-        x.addResource(res);
-
-        let reslist = x.getResources({
-            reskey: "foobar"
-        });
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-        test.equal(reslist[0].getSource(), "Asdf asdf");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "webapp");
-        test.ok(!reslist[0].getComment());
-
-        test.done();
-    },
-
-    testXliffAddMultipleResourcesAddInstances: function(test) {
-        test.expect(17);
-
-        const x = new Xliff({
-            allowDups: true
-        });
-        test.ok(x);
-
-        let res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        // this one has the same source, locale, key, and file
-        // so it should create an instance of the first one
-        res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            comment: "blah blah blah",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        let reslist = x.getResources({
-            reskey: "foobar"
-        });
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-        test.equal(reslist[0].getSource(), "Asdf asdf");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "webapp");
-        test.ok(!reslist[0].getComment());
-
-        let instances = reslist[0].getInstances();
-        test.ok(instances);
-        test.equal(instances.length, 1);
-
-        test.equal(instances[0].getSource(), "Asdf asdf");
-        test.equal(instances[0].getSourceLocale(), "en-US");
-        test.equal(instances[0].getKey(), "foobar");
-        test.equal(instances[0].getPath(), "foo/bar/asdf.java");
-        test.equal(instances[0].getProject(), "webapp");
-        test.equal(instances[0].getComment(), "blah blah blah");
-
-        test.done();
-    },
-
-    testXliffSerializeWithResourcesWithInstances: function(test) {
-        test.expect(2);
-
-        const x = new Xliff({
-            allowDups: true
-        });
-        test.ok(x);
-
-        let res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        // this one has the same source, locale, key, and file
-        // so it should create an instance of the first one
-        res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            comment: "blah blah blah",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        let expected =
-            '<?xml version="1.0" encoding="utf-8"?>\n' +
-            '<xliff version="1.2">\n' +
-            '  <file original="foo/bar/asdf.java" source-language="en-US" product-name="webapp">\n' +
-            '    <body>\n' +
-            '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
-            '        <source>Asdf asdf</source>\n' +
-            '      </trans-unit>\n' +
-            '      <trans-unit id="2" resname="foobar" restype="string" datatype="plaintext">\n' +
-            '        <source>Asdf asdf</source>\n' +
-            '        <note>blah blah blah</note>\n' +
-            '      </trans-unit>\n' +
-            '    </body>\n' +
-            '  </file>\n' +
-            '</xliff>';
-
-        let actual = x.serialize();
-        diff(actual, expected);
-
-        test.equal(actual, expected);
-
-        test.done();
-    },
-
-    testXliffSerializeWithTranslationUnitsWithInstances: function(test) {
-        test.expect(2);
-
-        const x = new Xliff({
-            allowDups: true
-        });
-        test.ok(x);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "bababa",
-            "sourceLocale": "en-US",
-            "target": "ababab",
-            "targetLocale": "fr-FR",
-            "key": "asdf",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2333,
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "bababa",
-            "sourceLocale": "en-US",
-            "target": "ababab",
-            "targetLocale": "fr-FR",
-            "key": "asdf",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a different comment"
-        }));
-
-        let expected =
-            '<?xml version="1.0" encoding="utf-8"?>\n' +
-            '<xliff version="1.2">\n' +
-            '  <file original="/a/b/asdf.js" source-language="en-US" target-language="fr-FR" product-name="iosapp">\n' +
-            '    <body>\n' +
-            '      <trans-unit id="2333" resname="asdf" restype="string" x-context="asdfasdf">\n' +
-            '        <source>bababa</source>\n' +
-            '        <target>ababab</target>\n' +
-            '        <note>this is a comment</note>\n' +
-            '      </trans-unit>\n' +
-            '      <trans-unit id="2334" resname="asdf" restype="string" x-context="asdfasdf">\n' +
-            '        <source>bababa</source>\n' +
-            '        <target>ababab</target>\n' +
-            '        <note>this is a different comment</note>\n' +
-            '      </trans-unit>\n' +
-            '    </body>\n' +
-            '  </file>\n' +
-            '</xliff>';
-
-        let actual = x.serialize();
-        diff(actual, expected);
-
-        test.equal(actual, expected);
-
-        test.done();
-    },
-
-    testXliffDeserializeCreateInstances: function(test) {
+    testXliffDeserializeWithSourceOnly: function(test) {
         test.expect(21);
 
-        const x = new Xliff({
-            allowDups: true
-        });
+        const x = new Xliff();
         test.ok(x);
 
         x.deserialize(
-            '<?xml version="1.0" encoding="utf-8"?>\n' +
-            '<xliff version="1.2">\n' +
-            '  <file original="/a/b/asdf.js" source-language="en-US" target-language="fr-FR" product-name="iosapp">\n' +
-            '    <body>\n' +
-            '      <trans-unit id="2333" resname="asdf" restype="string" x-context="asdfasdf">\n' +
-            '        <source>bababa</source>\n' +
-            '        <target>ababab</target>\n' +
-            '        <note>this is a comment</note>\n' +
-            '      </trans-unit>\n' +
-            '      <trans-unit id="2334" resname="asdf" restype="string" x-context="asdfasdf">\n' +
-            '        <source>bababa</source>\n' +
-            '        <target>ababab</target>\n' +
-            '        <note>this is a different comment</note>\n' +
-            '      </trans-unit>\n' +
-            '    </body>\n' +
-            '  </file>\n' +
-            '</xliff>');
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string" datatype="plaintext">\n' +
+                '        <source>baby baby</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
 
-        let reslist = x.getResources();
+        let tulist = x.getTranslationUnits();
 
-        test.ok(reslist);
+        test.ok(tulist);
 
-        test.equal(reslist.length, 1);
+        test.equal(tulist.length, 2);
 
-        test.equal(reslist[0].getTarget(), "ababab");
-        test.equal(reslist[0].getTargetLocale(), "fr-FR");
-        test.equal(reslist[0].getKey(), "asdf");
-        test.equal(reslist[0].getPath(), "/a/b/asdf.js");
-        test.equal(reslist[0].getProject(), "iosapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].context, "asdfasdf");
-        test.equal(reslist[0].comment, "this is a comment");
+        test.equal(tulist[0].source, "Asdf asdf");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.ok(!tulist[0].target);
+        test.equal(tulist[0].targetLocale, "de-DE");
+        test.equal(tulist[0].key, "foobar");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].project, "androidapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "1");
 
-        let instances = reslist[0].getInstances();
-        test.ok(instances);
-        test.equal(instances.length, 1);
+        test.equal(tulist[1].source, "baby baby");
+        test.equal(tulist[1].sourceLocale, "en-US");
+        test.ok(!tulist[1].target);
+        test.equal(tulist[1].targetLocale, "fr-FR");
+        test.equal(tulist[1].key, "huzzah");
+        test.equal(tulist[1].file, "foo/bar/j.java");
+        test.equal(tulist[1].project, "webapp");
+        test.equal(tulist[1].resType, "string");
+        test.equal(tulist[1].id, "2");
 
-        test.equal(instances[0].getTarget(), "ababab");
-        test.equal(instances[0].getTargetLocale(), "fr-FR");
-        test.equal(instances[0].getKey(), "asdf");
-        test.equal(instances[0].getPath(), "/a/b/asdf.js");
-        test.equal(instances[0].getProject(), "iosapp");
-        test.equal(instances[0].resType, "string");
-        test.equal(instances[0].context, "asdfasdf");
-        test.equal(instances[0].comment, "this is a different comment");
+        test.done();
+    },
+
+    testXliffDeserializeWithSourceAndTarget: function(test) {
+        test.expect(21);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="string">\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '        <target>foobarfoo</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>baby baby</source>\n' +
+                '        <target>bebe bebe</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        // console.log("x is " + JSON.stringify(x, undefined, 4));
+        let tulist = x.getTranslationUnits();
+        // console.log("x is now " + JSON.stringify(x, undefined, 4));
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 2);
+
+        test.equal(tulist[0].source, "Asdf asdf");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "foobar");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].project, "androidapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "1");
+        test.equal(tulist[0].target, "foobarfoo");
+        test.equal(tulist[0].targetLocale, "de-DE");
+
+        test.equal(tulist[1].source, "baby baby");
+        test.equal(tulist[1].sourceLocale, "en-US");
+        test.equal(tulist[1].key, "huzzah");
+        test.equal(tulist[1].file, "foo/bar/j.java");
+        test.equal(tulist[1].project, "webapp");
+        test.equal(tulist[1].resType, "string");
+        test.equal(tulist[1].id, "2");
+        test.equal(tulist[1].target, "bebe bebe");
+        test.equal(tulist[1].targetLocale, "fr-FR");
+
+        test.done();
+    },
+
+    testXliffDeserializeWithXMLUnescaping: function(test) {
+        test.expect(19);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="string">\n' +
+                '        <source>Asdf &lt;b&gt;asdf&lt;/b&gt;</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>baby &amp;lt;b&amp;gt;baby&amp;lt;/b&amp;gt;</source>\n' +   // double escaped!
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 2);
+
+        test.equal(tulist[0].source, "Asdf <b>asdf</b>");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "foobar");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].project, "androidapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "1");
+        test.ok(!tulist[0].target);
+
+        test.equal(tulist[1].source, "baby &lt;b&gt;baby&lt;/b&gt;");
+        test.equal(tulist[1].sourceLocale, "en-US");
+        test.equal(tulist[1].key, "huzzah");
+        test.equal(tulist[1].file, "foo/bar/j.java");
+        test.equal(tulist[1].project, "webapp");
+        test.equal(tulist[1].resType, "string");
+        test.equal(tulist[1].id, "2");
+        test.ok(!tulist[1].target);
+
+        test.done();
+    },
+
+    testXliffDeserializeWithXMLUnescapingInResname: function(test) {
+        test.expect(19);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar &lt;a>link&lt;/a>" restype="string">\n' +
+                '        <source>Asdf &lt;b&gt;asdf&lt;/b&gt;</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="&lt;b>huzzah&lt;/b>" restype="string">\n' +
+                '        <source>baby &amp;lt;b&amp;gt;baby&amp;lt;/b&amp;gt;</source>\n' +   // double escaped!
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 2);
+
+        test.equal(tulist[0].source, "Asdf <b>asdf</b>");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "foobar <a>link</a>");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].project, "androidapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "1");
+        test.ok(!tulist[0].target);
+
+        test.equal(tulist[1].source, "baby &lt;b&gt;baby&lt;/b&gt;");
+        test.equal(tulist[1].sourceLocale, "en-US");
+        test.equal(tulist[1].key, "<b>huzzah</b>");
+        test.equal(tulist[1].file, "foo/bar/j.java");
+        test.equal(tulist[1].project, "webapp");
+        test.equal(tulist[1].resType, "string");
+        test.equal(tulist[1].id, "2");
+        test.ok(!tulist[1].target);
+
+        test.done();
+    },
+
+    testXliffDeserializeWithEscapedNewLines: function(test) {
+        test.expect(17);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="en-CA" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="string">\n' +
+                '        <source>a\\nb</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="en-CA" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>e\\nh</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 2);
+
+        test.equal(tulist[0].source, "a\\nb");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "foobar");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].project, "androidapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "1");
+
+        test.equal(tulist[1].source, "e\\nh");
+        test.equal(tulist[1].sourceLocale, "en-US");
+        test.equal(tulist[1].key, "huzzah");
+        test.equal(tulist[1].file, "foo/bar/j.java");
+        test.equal(tulist[1].project, "webapp");
+        test.equal(tulist[1].resType, "string");
+        test.equal(tulist[1].id, "2");
+
+        test.done();
+    },
+
+    testXliffDeserializeWithEscapedNewLinesInResname: function(test) {
+        test.expect(17);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="en-CA" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar\\n\\nasdf" restype="string">\n' +
+                '        <source>a\\nb</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="en-CA" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah\\t\\n" restype="string">\n' +
+                '        <source>e\\nh</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 2);
+
+        test.equal(tulist[0].source, "a\\nb");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "foobar\\n\\nasdf");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].project, "androidapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "1");
+
+        test.equal(tulist[1].source, "e\\nh");
+        test.equal(tulist[1].sourceLocale, "en-US");
+        test.equal(tulist[1].key, "huzzah\\t\\n");
+        test.equal(tulist[1].file, "foo/bar/j.java");
+        test.equal(tulist[1].project, "webapp");
+        test.equal(tulist[1].resType, "string");
+        test.equal(tulist[1].id, "2");
+
+        test.done();
+    },
+
+    testXliffDeserializeWithContext: function(test) {
+        test.expect(19);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="string" x-context="na na na">\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string" x-context="asdf">\n' +
+                '        <source>baby baby</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 2);
+
+        test.equal(tulist[0].source, "Asdf asdf");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "foobar");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].project, "androidapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "1");
+        test.equal(tulist[0].context, "na na na");
+
+        test.equal(tulist[1].source, "baby baby");
+        test.equal(tulist[1].sourceLocale, "en-US");
+        test.equal(tulist[1].key, "huzzah");
+        test.equal(tulist[1].file, "foo/bar/j.java");
+        test.equal(tulist[1].project, "webapp");
+        test.equal(tulist[1].resType, "string");
+        test.equal(tulist[1].id, "2");
+        test.equal(tulist[1].context, "asdf");
+
+        test.done();
+    },
+
+    testXliffDeserializeEmptySource: function(test) {
+        test.expect(12);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="string" x-context="na na na">\n' +
+                '        <source></source>\n' +
+                '        <target>Baby Baby</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>baby baby</source>\n' +
+                '        <target>bebe bebe</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+
+        test.equal(tulist[0].source, "baby baby");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "huzzah");
+        test.equal(tulist[0].file, "foo/bar/j.java");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "2");
+
+        test.equal(tulist[0].target, "bebe bebe");
+        test.equal(tulist[0].targetLocale, "fr-FR");
+
+        test.done();
+    },
+
+    testXliffDeserializeEmptyTarget: function(test) {
+        test.expect(17);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="string">\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>baby baby</source>\n' +
+                '        <target></target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 2);
+
+        test.equal(tulist[0].source, "Asdf asdf");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "foobar");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].project, "androidapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "1");
+
+        test.equal(tulist[1].source, "baby baby");
+        test.equal(tulist[1].sourceLocale, "en-US");
+        test.equal(tulist[1].key, "huzzah");
+        test.equal(tulist[1].file, "foo/bar/j.java");
+        test.equal(tulist[1].project, "webapp");
+        test.equal(tulist[1].resType, "string");
+        test.equal(tulist[1].id, "2");
+
+        test.done();
+    },
+
+    testXliffDeserializeWithMrkTagInTarget: function(test) {
+        test.expect(12);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>baby baby</source><seg-source><mrk mtype="seg" mid="4">baby baby</mrk></seg-source><target><mrk mtype="seg" mid="4">bebe bebe</mrk></target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+
+        test.equal(tulist[0].source, "baby baby");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "huzzah");
+        test.equal(tulist[0].file, "foo/bar/j.java");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "2");
+
+        test.equal(tulist[0].target, "bebe bebe");
+        test.equal(tulist[0].targetLocale, "fr-FR");
+
+        test.done();
+    },
+
+    testXliffDeserializeWithEmptyMrkTagInTarget: function(test) {
+        test.expect(10);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>baby baby</source><seg-source><mrk mtype="seg" mid="4">baby baby</mrk></seg-source><target><mrk mtype="seg" mid="4"/></target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+
+        test.equal(tulist[0].source, "baby baby");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "huzzah");
+        test.equal(tulist[0].file, "foo/bar/j.java");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "2");
+
+        test.done();
+    },
+
+    testXliffDeserializeWithMultipleMrkTagsInTargetEuro: function(test) {
+        test.expect(12);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>baby baby</source><seg-source><mrk mtype="seg" mid="4">baby baby</mrk></seg-source><target><mrk mtype="seg" mid="4">This is segment 1.</mrk> <mrk mtype="seg" mid="5">This is segment 2.</mrk> <mrk mtype="seg" mid="6">This is segment 3.</mrk></target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+
+        test.equal(tulist[0].source, "baby baby");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "huzzah");
+        test.equal(tulist[0].file, "foo/bar/j.java");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "2");
+
+        test.equal(tulist[0].target, "This is segment 1. This is segment 2. This is segment 3.");
+        test.equal(tulist[0].targetLocale, "fr-FR");
+
+        test.done();
+    },
+
+    testXliffDeserializeWithMultipleMrkTagsInTargetAsian: function(test) {
+        test.expect(12);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="zh-Hans-CN" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>baby baby</source><seg-source><mrk mtype="seg" mid="4">baby baby</mrk></seg-source><target><mrk mtype="seg" mid="4">This is segment 1.</mrk> <mrk mtype="seg" mid="5">This is segment 2.</mrk> <mrk mtype="seg" mid="6">This is segment 3.</mrk></target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+
+        test.equal(tulist[0].source, "baby baby");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "huzzah");
+        test.equal(tulist[0].file, "foo/bar/j.java");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "2");
+
+        test.equal(tulist[0].target, "This is segment 1.This is segment 2.This is segment 3.");
+        test.equal(tulist[0].targetLocale, "zh-Hans-CN");
+
+        test.done();
+    },
+
+    testXliffDeserializePreserveSourceWhitespace: function(test) {
+        test.expect(9);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="UI/AddAnotherButtonView.m" source-language="en-US" target-language="es-US" product-name="iosapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="196" resname="      Add Another" restype="string" datatype="x-objective-c">\n' +
+                '        <source>      Add Another</source>\n' +
+                '        <target>Añadir Otro</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+
+        test.equal(tulist[0].source, "      Add Another");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "      Add Another");
+        test.equal(tulist[0].file, "UI/AddAnotherButtonView.m");
+        test.equal(tulist[0].project, "iosapp");
+        test.equal(tulist[0].resType, "string");
+
+        test.done();
+    },
+
+    testXliffDeserializePreserveTargetWhitespace: function(test) {
+        test.expect(9);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="UI/AddAnotherButtonView.m" source-language="en-US" target-language="es-US" product-name="iosapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="196" resname="      Add Another" restype="string" datatype="x-objective-c">\n' +
+                '        <source>      Add Another</source>\n' +
+                '        <target> Añadir    Otro  </target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+
+        test.equal(tulist[0].target, " Añadir    Otro  ");
+        test.equal(tulist[0].targetLocale, "es-US");
+        test.equal(tulist[0].key, "      Add Another");
+        test.equal(tulist[0].file, "UI/AddAnotherButtonView.m");
+        test.equal(tulist[0].project, "iosapp");
+        test.equal(tulist[0].resType, "string");
 
         test.done();
     },
 
     testXliffDeserializeStillAcceptsAnnotatesAttr: function(test) {
-        test.expect(21);
+        test.expect(19);
 
         const x = new Xliff({
             allowDups: true
@@ -3780,35 +1618,30 @@ export const testXliff10 = {
             '  </file>\n' +
             '</xliff>');
 
-        let reslist = x.getResources();
+        let tulist = x.getTranslationUnits();
 
-        test.ok(reslist);
+        test.ok(tulist);
 
-        test.equal(reslist.length, 1);
+        test.equal(tulist.length, 2);
 
-        test.equal(reslist[0].getTarget(), "ababab");
-        test.equal(reslist[0].getTargetLocale(), "fr-FR");
-        test.equal(reslist[0].getKey(), "asdf");
-        test.equal(reslist[0].getPath(), "/a/b/asdf.js");
-        test.equal(reslist[0].getProject(), "iosapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].context, "asdfasdf");
-        test.equal(reslist[0].comment, "this is a comment");
+        test.equal(tulist[0].target, "ababab");
+        test.equal(tulist[0].targetLocale, "fr-FR");
+        test.equal(tulist[0].key, "asdf");
+        test.equal(tulist[0].file, "/a/b/asdf.js");
+        test.equal(tulist[0].project, "iosapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].context, "asdfasdf");
+        test.equal(tulist[0].comment, "this is a comment");
 
-        let instances = reslist[0].getInstances();
-        test.ok(instances);
-        test.equal(instances.length, 1);
-
-        test.equal(instances[0].getTarget(), "ababab");
-        test.equal(instances[0].getTargetLocale(), "fr-FR");
-        test.equal(instances[0].getKey(), "asdf");
-        test.equal(instances[0].getPath(), "/a/b/asdf.js");
-        test.equal(instances[0].getProject(), "iosapp");
-        test.equal(instances[0].resType, "string");
-        test.equal(instances[0].context, "asdfasdf");
-        test.equal(instances[0].comment, "this is a different comment");
+        test.equal(tulist[1].target, "ababab");
+        test.equal(tulist[1].targetLocale, "fr-FR");
+        test.equal(tulist[1].key, "asdf");
+        test.equal(tulist[1].file, "/a/b/asdf.js");
+        test.equal(tulist[1].project, "iosapp");
+        test.equal(tulist[1].resType, "string");
+        test.equal(tulist[1].context, "asdfasdf");
+        test.equal(tulist[1].comment, "this is a different comment");
 
         test.done();
     }
-*/
 };

--- a/test/testXliff10.js
+++ b/test/testXliff10.js
@@ -1,0 +1,3439 @@
+/*
+ * testXliff.js - test the Xliff object with v1.2 xliff files
+ *
+ * Copyright © 2016-2017, 2019-2022 HealthTap, Inc. and JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Xliff from "../src/Xliff.js";
+import TranslationUnit from "../src/TranslationUnit.js";
+
+function diff(a, b) {
+    var min = Math.min(a.length, b.length);
+
+    for (var i = 0; i < min; i++) {
+        if (a[i] !== b[i]) {
+            console.log("Found difference at character " + i);
+            console.log("a: " + a.substring(i));
+            console.log("b: " + b.substring(i));
+            break;
+        }
+    }
+}
+
+export const testXliff10 = {
+    testXliffConstructor: function(test) {
+        test.expect(1);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        test.done();
+    },
+
+    testXliffConstructorIsEmpty: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        test.equal(x.size(), 0);
+
+        test.done();
+    },
+
+    testXliffConstructorFull: function(test) {
+        test.expect(7);
+
+        const x = new Xliff({
+            "tool-id": "loctool",
+            "tool-name": "Localization Tool",
+            "tool-version": "1.2.34",
+            "tool-company": "My Company, Inc.",
+            copyright: "Copyright 2016, My Company, Inc. All rights reserved.",
+            path: "a/b/c.xliff"
+        });
+        test.ok(x);
+
+        test.equal(x["tool-id"], "loctool");
+        test.equal(x["tool-name"], "Localization Tool"),
+        test.equal(x["tool-version"], "1.2.34"),
+        test.equal(x["tool-company"], "My Company, Inc."),
+        test.equal(x.copyright, "Copyright 2016, My Company, Inc. All rights reserved."),
+        test.equal(x.path, "a/b/c.xliff");
+
+        test.done();
+    },
+
+    testXliffAddTranslationUnit: function(test) {
+        test.expect(11);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        var tu = new TranslationUnit({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            file: "foo/bar/asdf.java",
+            project: "webapp",
+            resType: "string",
+            state: "new",
+            comment: "This is a comment",
+            datatype: "java"
+        });
+
+        x.addTranslationUnit(tu);
+
+        var tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+        test.equal(tulist[0].source, "Asdf asdf");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "foobar");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].state, "new");
+        test.equal(tulist[0].comment, "This is a comment");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].datatype, "java");
+
+        test.done();
+    },
+
+/*
+    testXliffSize: function(test) {
+        test.expect(3);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            comment: "this is a comment",
+            project: "webapp"
+        });
+
+        test.equal(x.size(), 0);
+
+        x.addResource(res);
+
+        test.equal(x.size(), 1);
+
+        test.done();
+    },
+
+    testXliffAddMultipleResources: function(test) {
+        test.expect(8);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        res = new ResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        var reslist = x.getResources({
+            reskey: "foobar"
+        });
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+        test.equal(reslist[0].getSource(), "Asdf asdf");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "webapp");
+
+        test.done();
+    },
+
+    testXliffAddMultipleResourcesRightSize: function(test) {
+        test.expect(3);
+
+        const x = new Xliff();
+        test.ok(x);
+        test.equal(x.size(), 0);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        res = new ResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        test.equal(x.size(), 2);
+
+        test.done();
+    },
+
+    testXliffAddMultipleResourcesOverwrite: function(test) {
+        test.expect(9);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        // this one has the same source, locale, key, and file
+        // so it should overwrite the one above
+        res = new ResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            comment: "blah blah blah",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        var reslist = x.getResources({
+            reskey: "foobar"
+        });
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+        test.equal(reslist[0].getSource(), "baby baby");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "webapp");
+        test.equal(reslist[0].getComment(), "blah blah blah");
+
+        test.done();
+    },
+
+    testXliffAddMultipleResourcesOverwriteRightSize: function(test) {
+        test.expect(4);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        test.equal(x.size(), 0);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        test.equal(x.size(), 1);
+
+        // this one has the same source, locale, key, and file
+        // so it should overwrite the one above
+        res = new ResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            comment: "blah blah blah",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        test.equal(x.size(), 1);
+
+        test.done();
+    },
+
+    testXliffAddMultipleResourcesNoOverwrite: function(test) {
+        test.expect(13);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        // this one has a different locale
+        // so it should not overwrite the one above
+        res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "fr-FR",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            comment: "blah blah blah",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        var reslist = x.getResources({
+            reskey: "foobar"
+        });
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 2);
+
+        test.equal(reslist[0].getSource(), "Asdf asdf");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.ok(!reslist[0].getComment());
+
+        test.equal(reslist[1].getSource(), "Asdf asdf");
+        test.equal(reslist[1].getSourceLocale(), "fr-FR");
+        test.equal(reslist[1].getKey(), "foobar");
+        test.equal(reslist[1].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[1].getComment(), "blah blah blah");
+
+        test.done();
+    },
+
+    testXliffAddResourceDontAddSourceLocaleAsTarget: function(test) {
+        test.expect(2);
+
+        const x = new Xliff({
+            sourceLocale: "en-US"
+        });
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        // should not add this one
+        res = new ResourceString({
+            source: "baby baby",
+            target: "babes babes",
+            targetLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        test.equal(x.size(), 1);
+
+        test.done();
+    },
+
+    testXliffGetResourcesMultiple: function(test) {
+        test.expect(11);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp",
+            origin: "source"
+        });
+
+        x.addResource(res);
+
+        res = new ResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            origin: "origin"
+        });
+
+        x.addResource(res);
+
+        var reslist = x.getResources({
+            sourceLocale: "en-US"
+        });
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 2);
+
+        test.equal(reslist[0].getSource(), "Asdf asdf");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+
+        test.equal(reslist[1].getSource(), "baby baby");
+        test.equal(reslist[1].getSourceLocale(), "en-US");
+        test.equal(reslist[1].getKey(), "huzzah");
+        test.equal(reslist[1].getPath(), "foo/bar/j.java");
+
+        test.done();
+    },
+
+    testXliffSerializeWithContext: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        var res = new ContextResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            target: "gutver",
+            targetLocale: "nl-NL",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            context: "foobar"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="1.2">\n' +
+            '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="nl-NL" product-name="androidapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext" x-context="foobar">\n' +
+            '        <source>Asdf asdf</source>\n' +
+            '        <target>gutver</target>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliffSerializeWithSourceOnly: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        var res = new ContextResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            targetLocale: "de-DE"
+        });
+
+        x.addResource(res);
+
+        res = new ContextResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            targetLocale: "fr-FR"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="1.2">\n' +
+            '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
+            '        <source>Asdf asdf</source>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="2" resname="huzzah" restype="string" datatype="plaintext">\n' +
+            '        <source>baby baby</source>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliffSerializeWithFlavors: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        var res = new ContextResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            target: "gutver",
+            targetLocale: "nl-NL",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            origin: "source",
+            flavor: "chocolate"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="1.2">\n' +
+            '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="nl-NL" product-name="androidapp" x-flavor="chocolate">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
+            '        <source>Asdf asdf</source>\n' +
+            '        <target>gutver</target>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliffSerializeWithSourceOnlyAndPlurals: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        var res = new ContextResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            targetLocale: "de-DE"
+        });
+
+        x.addResource(res);
+
+        res = new ResourcePlural({
+            sourceStrings: {
+                "zero": "0",
+                "one": "1",
+                "few": "few"
+            },
+            sourceLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            targetLocale: "fr-FR"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="1.2">\n' +
+            '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
+            '        <source>Asdf asdf</source>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="2" resname="huzzah" restype="plural" datatype="x-android-resource" extype="zero">\n' +
+            '        <source>0</source>\n' +
+            '        <note>{"pluralForm":"zero","pluralFormOther":"huzzah"}</note>\n' +
+            '      </trans-unit>\n' +
+            '      <trans-unit id="3" resname="huzzah" restype="plural" datatype="x-android-resource" extype="one">\n' +
+            '        <source>1</source>\n' +
+            '        <note>{"pluralForm":"one","pluralFormOther":"huzzah"}</note>\n' +
+            '      </trans-unit>\n' +
+            '      <trans-unit id="4" resname="huzzah" restype="plural" datatype="x-android-resource" extype="few">\n' +
+            '        <source>few</source>\n' +
+            '        <note>{"pluralForm":"few","pluralFormOther":"huzzah"}</note>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliffSerializeWithSourceOnlyAndArray: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        var res = new ContextResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            targetLocale: "de-DE"
+        });
+
+        x.addResource(res);
+
+        res = new ResourceArray({
+            sourceArray: ["one", "two", "three"],
+            sourceLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            targetLocale: "fr-FR"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="1.2">\n' +
+            '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
+            '        <source>Asdf asdf</source>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="2" resname="huzzah" restype="array" datatype="x-android-resource" extype="0">\n' +
+            '        <source>one</source>\n' +
+            '      </trans-unit>\n' +
+            '      <trans-unit id="3" resname="huzzah" restype="array" datatype="x-android-resource" extype="1">\n' +
+            '        <source>two</source>\n' +
+            '      </trans-unit>\n' +
+            '      <trans-unit id="4" resname="huzzah" restype="array" datatype="x-android-resource" extype="2">\n' +
+            '        <source>three</source>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliffSerializeWithExplicitIds: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            target: "baby baby",
+            targetLocale: "nl-NL",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            origin: "target",
+            id: 4444444
+        });
+
+        x.addResource(res);
+
+        res = new ResourceString({
+            source: "abcdef",
+            sourceLocale: "en-US",
+            target: "hijklmn",
+            targetLocale: "nl-NL",
+            key: "asdf",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="nl-NL" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="4444444" resname="foobar" restype="string" datatype="plaintext">\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '        <target>baby baby</target>\n' +
+                '      </trans-unit>\n' +
+                '      <trans-unit id="4444445" resname="asdf" restype="string" datatype="plaintext">\n' +
+                '        <source>abcdef</source>\n' +
+                '        <target>hijklmn</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>';
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testXliffSerializeWithSourceAndTarget: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            target: "foobarfoo",
+            targetLocale: "de-DE",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        res = new ResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            target: "bebe bebe",
+            targetLocale: "fr-FR",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        diff(x.serialize(),
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '        <target>foobarfoo</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string" datatype="plaintext">\n' +
+                '        <source>baby baby</source>\n' +
+                '        <target>bebe bebe</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        test.equal(x.serialize(),
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '        <target>foobarfoo</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string" datatype="plaintext">\n' +
+                '        <source>baby baby</source>\n' +
+                '        <target>bebe bebe</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        test.done();
+    },
+
+    testXliffSerializeWithSourceAndTargetAndComment: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            target: "foobarfoo",
+            targetLocale: "de-DE",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp",
+            comment: "foobar is where it's at!"
+        });
+
+        x.addResource(res);
+
+        res = new ResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            target: "bebe bebe",
+            targetLocale: "fr-FR",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            comment: "come & enjoy it with us"
+        });
+
+        x.addResource(res);
+
+        var expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '        <target>foobarfoo</target>\n' +
+                '        <note>foobar is where it\'s at!</note>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string" datatype="plaintext">\n' +
+                '        <source>baby baby</source>\n' +
+                '        <target>bebe bebe</target>\n' +
+                '        <note>come &amp; enjoy it with us</note>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>';
+
+        var actual = x.serialize();
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testXliffSerializeWithHeader: function(test) {
+        test.expect(2);
+
+        const x = new Xliff({
+            "tool-id": "loctool",
+            "tool-name": "Localization Tool",
+            "tool-version": "1.2.34",
+            "tool-company": "My Company, Inc.",
+            copyright: "Copyright 2016, My Company, Inc. All rights reserved.",
+            path: "a/b/c.xliff"
+        });
+        test.ok(x);
+
+        res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            target: "baby baby",
+            targetLocale: "nl-NL",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="nl-NL" product-name="webapp">\n' +
+                '    <header>\n' +
+                '      <tool tool-id="loctool" tool-name="Localization Tool" tool-version="1.2.34" tool-company="My Company, Inc." copyright="Copyright 2016, My Company, Inc. All rights reserved."/>\n' +
+                '    </header>\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '        <target>baby baby</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliffSerializeWithPlurals: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        res = new ResourcePlural({
+            sourceStrings: {
+                "one": "There is 1 object.",
+                "other": "There are {n} objects."
+            },
+            sourceLocale: "en-US",
+            targetStrings: {
+                "one": "Da gibts 1 Objekt.",
+                "other": "Da gibts {n} Objekten."
+            },
+            targetLocale: "de-DE",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            resType: "plural",
+            origin: "target",
+            autoKey: true,
+            state: "new",
+            datatype: "ruby"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="plural" datatype="ruby" extype="one">\n' +
+                '        <source>There is 1 object.</source>\n' +
+                '        <target state="new">Da gibts 1 Objekt.</target>\n' +
+                '        <note>{"pluralForm":"one","pluralFormOther":"foobar"}</note>\n' +
+                '      </trans-unit>\n' +
+                '      <trans-unit id="2" resname="foobar" restype="plural" datatype="ruby" extype="other">\n' +
+                '        <source>There are {n} objects.</source>\n' +
+                '        <target state="new">Da gibts {n} Objekten.</target>\n' +
+                '        <note>{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>';
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testXliffSerializeWithPluralsToLangWithMorePluralsThanEnglish: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        res = new ResourcePlural({
+            sourceStrings: {
+                "one": "There is 1 object.",
+                "other": "There are {n} objects."
+            },
+            sourceLocale: "en-US",
+            targetStrings: {
+                "one": "Имеется {n} объект.",
+                "few": "Есть {n} объекта.",
+                "other": "Всего {n} объектов."
+            },
+            targetLocale: "ru-RU",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            resType: "plural",
+            origin: "target",
+            autoKey: true,
+            state: "new",
+            datatype: "ruby"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="ru-RU" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="plural" datatype="ruby" extype="one">\n' +
+                '        <source>There is 1 object.</source>\n' +
+                '        <target state="new">Имеется {n} объект.</target>\n' +
+                '        <note>{"pluralForm":"one","pluralFormOther":"foobar"}</note>\n' +
+                '      </trans-unit>\n' +
+                '      <trans-unit id="2" resname="foobar" restype="plural" datatype="ruby" extype="few">\n' +
+                '        <source>There are {n} objects.</source>\n' +
+                '        <target state="new">Есть {n} объекта.</target>\n' +
+                '        <note>{"pluralForm":"few","pluralFormOther":"foobar"}</note>\n' +
+                '      </trans-unit>\n' +
+                '      <trans-unit id="3" resname="foobar" restype="plural" datatype="ruby" extype="other">\n' +
+                '        <source>There are {n} objects.</source>\n' +
+                '        <target state="new">Всего {n} объектов.</target>\n' +
+                '        <note>{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>';
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testXliffSerializeWithArrays: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        res = new ResourceArray({
+            sourceArray: ["Zero", "One", "Two"],
+            sourceLocale: "en-US",
+            targetArray: ["Zero", "Eins", "Zwei"],
+            targetLocale: "de-DE",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="array" datatype="x-android-resource" extype="0">\n' +
+                '        <source>Zero</source>\n' +
+                '        <target>Zero</target>\n' +
+                '      </trans-unit>\n' +
+                '      <trans-unit id="2" resname="foobar" restype="array" datatype="x-android-resource" extype="1">\n' +
+                '        <source>One</source>\n' +
+                '        <target>Eins</target>\n' +
+                '      </trans-unit>\n' +
+                '      <trans-unit id="3" resname="foobar" restype="array" datatype="x-android-resource" extype="2">\n' +
+                '        <source>Two</source>\n' +
+                '        <target>Zwei</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>';
+        diff(actual, expected)
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliffSerializeWithXMLEscaping: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf <b>asdf</b>",
+            sourceLocale: "en-US",
+            target: "Asdf 'quotes'",
+            targetLocale: "de-DE",
+            key: 'foobar "asdf"',
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        res = new ResourceString({
+            source: "baby &lt;b&gt;baby&lt;/b&gt;",
+            sourceLocale: "en-US",
+            target: "baby #(test)",
+            targetLocale: "de-DE",
+            key: "huzzah &quot;asdf&quot; #(test)",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar &quot;asdf&quot;" restype="string" datatype="plaintext">\n' +
+                '        <source>Asdf &lt;b&gt;asdf&lt;/b&gt;</source>\n' +
+                '        <target>Asdf \'quotes\'</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="de-DE" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah &amp;quot;asdf&amp;quot; #(test)" restype="string" datatype="plaintext">\n' +
+                '        <source>baby &amp;lt;b&amp;gt;baby&amp;lt;/b&amp;gt;</source>\n' +   // double escaped!
+                '        <target>baby #(test)</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliffSerializeWithXMLEscapingInResname: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf <b>asdf</b>",
+            sourceLocale: "en-US",
+            target: "Asdf 'quotes'",
+            targetLocale: "de-DE",
+            key: 'foobar <i>asdf</i>',
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        res = new ResourceString({
+            source: "baby &lt;b&gt;baby&lt;/b&gt;",
+            sourceLocale: "en-US",
+            target: "baby #(test)",
+            targetLocale: "de-DE",
+            key: "huzzah <b>asdf</b> #(test)",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar &lt;i>asdf&lt;/i>" restype="string" datatype="plaintext">\n' +
+                '        <source>Asdf &lt;b&gt;asdf&lt;/b&gt;</source>\n' +
+                '        <target>Asdf \'quotes\'</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="de-DE" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah &lt;b>asdf&lt;/b> #(test)" restype="string" datatype="plaintext">\n' +
+                '        <source>baby &amp;lt;b&amp;gt;baby&amp;lt;/b&amp;gt;</source>\n' +   // double escaped!
+                '        <target>baby #(test)</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliffSerializeWithXMLEscapingWithQuotes: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Here are \"double\" and 'single' quotes.",
+            sourceLocale: "en-US",
+            target: "Hier zijn \"dubbel\" en 'singel' quotaties.",
+            targetLocale: "nl-NL",
+            key: '"double" and \'single\'',
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        test.equal(x.serialize(),
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="nl-NL" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="&quot;double&quot; and &apos;single&apos;" restype="string" datatype="plaintext">\n' +
+                '        <source>Here are "double" and \'single\' quotes.</source>\n' +
+                '        <target>Hier zijn "dubbel" en \'singel\' quotaties.</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        test.done();
+    },
+
+    testXliffSerializeWithEscapeCharsInResname: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            target: "Asdf translated",
+            targetLocale: "de-DE",
+            key: 'asdf \\n\\nasdf',
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        res = new ResourceString({
+            source: "asdf \\t\\n\\n asdf\\n",
+            sourceLocale: "en-US",
+            target: "fdsa \\t\\n\\n fdsa\\n",
+            targetLocale: "de-DE",
+            key: "asdf \\t\\n\\n asdf\\n",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="asdf \\n\\nasdf" restype="string" datatype="plaintext">\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '        <target>Asdf translated</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="de-DE" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="asdf \\t\\n\\n asdf\\n" restype="string" datatype="plaintext">\n' +
+                '        <source>asdf \\t\\n\\n asdf\\n</source>\n' +
+                '        <target>fdsa \\t\\n\\n fdsa\\n</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliffSerializeWithComments: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            target: "baby baby",
+            targetLocale: "nl-NL",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            comment: "A very nice string",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        test.equal(x.serialize(),
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="nl-NL" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '        <target>baby baby</target>\n' +
+                '        <note>A very nice string</note>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        test.done();
+    },
+
+    testXliffDeserializeWithSourceOnly: function(test) {
+        test.expect(21);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string" datatype="plaintext">\n' +
+                '        <source>baby baby</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 2);
+
+        test.equal(reslist[0].getSource(), "Asdf asdf");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.ok(!reslist[0].getTarget());
+        test.equal(reslist[0].getTargetLocale(), "de-DE");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), "1");
+
+        test.equal(reslist[1].getSource(), "baby baby");
+        test.equal(reslist[1].getSourceLocale(), "en-US");
+        test.ok(!reslist[1].getTarget());
+        test.equal(reslist[1].getTargetLocale(), "fr-FR");
+        test.equal(reslist[1].getKey(), "huzzah");
+        test.equal(reslist[1].getPath(), "foo/bar/j.java");
+        test.equal(reslist[1].getProject(), "webapp");
+        test.equal(reslist[1].resType, "string");
+        test.equal(reslist[1].getId(), "2");
+
+        test.done();
+    },
+
+    testXliffDeserializeWithSourceAndTarget: function(test) {
+        test.expect(21);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="string">\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '        <target>foobarfoo</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>baby baby</source>\n' +
+                '        <target>bebe bebe</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        // console.log("x is " + JSON.stringify(x, undefined, 4));
+        var reslist = x.getResources();
+        // console.log("x is now " + JSON.stringify(x, undefined, 4));
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 2);
+
+        test.equal(reslist[0].getSource(), "Asdf asdf");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), "1");
+        test.equal(reslist[0].getTarget(), "foobarfoo");
+        test.equal(reslist[0].getTargetLocale(), "de-DE");
+
+        test.equal(reslist[1].getSource(), "baby baby");
+        test.equal(reslist[1].getSourceLocale(), "en-US");
+        test.equal(reslist[1].getKey(), "huzzah");
+        test.equal(reslist[1].getPath(), "foo/bar/j.java");
+        test.equal(reslist[1].getProject(), "webapp");
+        test.equal(reslist[1].resType, "string");
+        test.equal(reslist[1].getId(), "2");
+        test.equal(reslist[1].getTarget(), "bebe bebe");
+        test.equal(reslist[1].getTargetLocale(), "fr-FR");
+
+        test.done();
+    },
+
+    testXliffDeserializeWithXMLUnescaping: function(test) {
+        test.expect(19);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="string">\n' +
+                '        <source>Asdf &lt;b&gt;asdf&lt;/b&gt;</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>baby &amp;lt;b&amp;gt;baby&amp;lt;/b&amp;gt;</source>\n' +   // double escaped!
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 2);
+
+        test.equal(reslist[0].getSource(), "Asdf <b>asdf</b>");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), "1");
+        test.ok(!reslist[0].getTarget());
+
+        test.equal(reslist[1].getSource(), "baby &lt;b&gt;baby&lt;/b&gt;");
+        test.equal(reslist[1].getSourceLocale(), "en-US");
+        test.equal(reslist[1].getKey(), "huzzah");
+        test.equal(reslist[1].getPath(), "foo/bar/j.java");
+        test.equal(reslist[1].getProject(), "webapp");
+        test.equal(reslist[1].resType, "string");
+        test.equal(reslist[1].getId(), "2");
+        test.ok(!reslist[1].getTarget());
+
+        test.done();
+    },
+
+    testXliffDeserializeWithXMLUnescapingInResname: function(test) {
+        test.expect(19);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar &lt;a>link&lt;/a>" restype="string">\n' +
+                '        <source>Asdf &lt;b&gt;asdf&lt;/b&gt;</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="&lt;b>huzzah&lt;/b>" restype="string">\n' +
+                '        <source>baby &amp;lt;b&amp;gt;baby&amp;lt;/b&amp;gt;</source>\n' +   // double escaped!
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 2);
+
+        test.equal(reslist[0].getSource(), "Asdf <b>asdf</b>");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar <a>link</a>");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), "1");
+        test.ok(!reslist[0].getTarget());
+
+        test.equal(reslist[1].getSource(), "baby &lt;b&gt;baby&lt;/b&gt;");
+        test.equal(reslist[1].getSourceLocale(), "en-US");
+        test.equal(reslist[1].getKey(), "<b>huzzah</b>");
+        test.equal(reslist[1].getPath(), "foo/bar/j.java");
+        test.equal(reslist[1].getProject(), "webapp");
+        test.equal(reslist[1].resType, "string");
+        test.equal(reslist[1].getId(), "2");
+        test.ok(!reslist[1].getTarget());
+
+        test.done();
+    },
+
+    testXliffDeserializeWithEscapedNewLines: function(test) {
+        test.expect(17);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="en-CA" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="string">\n' +
+                '        <source>a\\nb</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="en-CA" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>e\\nh</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 2);
+
+        test.equal(reslist[0].getSource(), "a\\nb");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), "1");
+
+        test.equal(reslist[1].getSource(), "e\\nh");
+        test.equal(reslist[1].getSourceLocale(), "en-US");
+        test.equal(reslist[1].getKey(), "huzzah");
+        test.equal(reslist[1].getPath(), "foo/bar/j.java");
+        test.equal(reslist[1].getProject(), "webapp");
+        test.equal(reslist[1].resType, "string");
+        test.equal(reslist[1].getId(), "2");
+
+        test.done();
+    },
+
+    testXliffDeserializeWithEscapedNewLinesInResname: function(test) {
+        test.expect(17);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="en-CA" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar\\n\\nasdf" restype="string">\n' +
+                '        <source>a\\nb</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="en-CA" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah\\t\\n" restype="string">\n' +
+                '        <source>e\\nh</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 2);
+
+        test.equal(reslist[0].getSource(), "a\\nb");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar\\n\\nasdf");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), "1");
+
+        test.equal(reslist[1].getSource(), "e\\nh");
+        test.equal(reslist[1].getSourceLocale(), "en-US");
+        test.equal(reslist[1].getKey(), "huzzah\\t\\n");
+        test.equal(reslist[1].getPath(), "foo/bar/j.java");
+        test.equal(reslist[1].getProject(), "webapp");
+        test.equal(reslist[1].resType, "string");
+        test.equal(reslist[1].getId(), "2");
+
+        test.done();
+    },
+
+    testXliffDeserializeWithPlurals: function(test) {
+        test.expect(10);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="plural" datatype="x-android-resource" extype="one">\n' +
+                '        <source>There is 1 object.</source>\n' +
+                '      </trans-unit>\n' +
+                '      <trans-unit id="2" resname="foobar" restype="plural" datatype="x-android-resource" extype="other">\n' +
+                '        <source>There are {n} objects.</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        // console.log("x is " + JSON.stringify(x, undefined, 4));
+
+        var reslist = x.getResources();
+
+        // console.log("after get resources x is " + JSON.stringify(x, undefined, 4));
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.deepEqual(reslist[0].getSourcePlurals(), {
+            one: "There is 1 object.",
+            other: "There are {n} objects."
+        });
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "plural");
+        test.equal(reslist[0].getId(), "1");
+
+        test.done();
+    },
+
+    testXliffDeserializeWithPluralsTranslated: function(test) {
+        test.expect(13);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="es-US" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="plural" datatype="x-android-resource" extype="one">\n' +
+                '        <source>There is 1 object.</source>\n' +
+                '        <target>Hay 1 objeto.</target>\n' +
+                '      </trans-unit>\n' +
+                '      <trans-unit id="2" resname="foobar" restype="plural" datatype="x-android-resource" extype="other">\n' +
+                '        <source>There are {n} objects.</source>\n' +
+                '        <target>Hay {n} objetos.</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        // console.log("x is " + JSON.stringify(x, undefined, 4));
+
+        var reslist = x.getResources();
+
+        // console.log("after get resources x is " + JSON.stringify(x, undefined, 4));
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.deepEqual(reslist[0].getSourcePlurals(), {
+            one: "There is 1 object.",
+            other: "There are {n} objects."
+        });
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "plural");
+        test.equal(reslist[0].getId(), "1");
+        test.equal(reslist[0].getOrigin(), "source");
+
+        test.deepEqual(reslist[0].getTargetPlurals(), {
+            one: "Hay 1 objeto.",
+            other: "Hay {n} objetos."
+        });
+        test.equal(reslist[0].getTargetLocale(), "es-US");
+
+        test.done();
+    },
+
+    testXliffDeserializeWithArrays: function(test) {
+        test.expect(10);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="array" datatype="x-android-resource" extype="0">\n' +
+                '        <source>Zero</source>\n' +
+                '      </trans-unit>\n' +
+                '      <trans-unit id="2" resname="foobar" restype="array" datatype="x-android-resource" extype="1">\n' +
+                '        <source>One</source>\n' +
+                '      </trans-unit>\n' +
+                '      <trans-unit id="3" resname="foobar" restype="array" datatype="x-android-resource" extype="2">\n' +
+                '        <source>Two</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.deepEqual(reslist[0].getSourceArray(), ["Zero", "One", "Two"]);
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "array");
+        test.ok(!reslist[0].getTargetArray());
+
+        test.done();
+    },
+
+    testXliffDeserializeWithArraysTranslated: function(test) {
+        test.expect(12);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="array" datatype="x-android-resource" extype="0">\n' +
+                '        <source>Zero</source>\n' +
+                '        <target>Zero</target>\n' +
+                '      </trans-unit>\n' +
+                '      <trans-unit id="2" resname="foobar" restype="array" datatype="x-android-resource" extype="1">\n' +
+                '        <source>One</source>\n' +
+                '        <target>Eins</target>\n' +
+                '      </trans-unit>\n' +
+                '      <trans-unit id="3" resname="foobar" restype="array" datatype="x-android-resource" extype="2">\n' +
+                '        <source>Two</source>\n' +
+                '        <target>Zwei</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.deepEqual(reslist[0].getSourceArray(), ["Zero", "One", "Two"]);
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "array");
+        test.equal(reslist[0].getOrigin(), "source");
+        test.deepEqual(reslist[0].getTargetArray(), ["Zero", "Eins", "Zwei"]);
+        test.equal(reslist[0].getTargetLocale(), "de-DE");
+
+        test.done();
+    },
+
+    testXliffDeserializeWithArraysAndTranslations: function(test) {
+        test.expect(20);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="res/values/arrays.xml" source-language="en-US" target-language="es-US" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="array" datatype="x-android-resource" extype="0">\n' +
+                '        <source>This is element 0</source>\n' +
+                '        <target>Este es 0</target>\n' +
+                '      </trans-unit>\n' +
+                '      <trans-unit id="3" resname="huzzah" restype="array" datatype="x-android-resource" extype="1">\n' +
+                '        <source>This is element 1</source>\n' +
+                '        <target>Este es 1</target>\n' +
+                '      </trans-unit>\n' +
+                '      <trans-unit id="4" resname="huzzah" restype="array" datatype="x-android-resource" extype="2">\n' +
+                '        <source>This is element 2</source>\n' +
+                '        <target>Este es 2</target>\n' +
+                '      </trans-unit>\n' +
+                '      <trans-unit id="5" resname="huzzah" restype="array" datatype="x-android-resource" extype="3">\n' +
+                '        <source>This is element 3</source>\n' +
+                '        <target>Este es 3</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getTargetLocale(), "es-US");
+        test.equal(reslist[0].getKey(), "huzzah");
+        test.equal(reslist[0].getPath(), "res/values/arrays.xml");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "array");
+        test.equal(reslist[0].getOrigin(), "source");
+
+        var items = reslist[0].getSourceArray();
+
+        test.equal(items.length, 4);
+        test.equal(items[0], "This is element 0");
+        test.equal(items[1], "This is element 1");
+        test.equal(items[2], "This is element 2");
+        test.equal(items[3], "This is element 3");
+
+        items = reslist[0].getTargetArray();
+
+        test.equal(items.length, 4);
+        test.equal(items[0], "Este es 0");
+        test.equal(items[1], "Este es 1");
+        test.equal(items[2], "Este es 2");
+        test.equal(items[3], "Este es 3");
+
+        test.done();
+    },
+
+    testXliffDeserializeWithArraysAndTranslationsPartial: function(test) {
+        test.expect(20);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="res/values/arrays.xml" source-language="en-US" target-language="es-US" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="5" resname="huzzah" restype="array" datatype="x-android-resource" extype="3">\n' +
+                '        <source>This is element 3</source>\n' +
+                '        <target>Este es 3</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getTargetLocale(), "es-US");
+        test.equal(reslist[0].getKey(), "huzzah");
+        test.equal(reslist[0].getPath(), "res/values/arrays.xml");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "array");
+        test.equal(reslist[0].getOrigin(), "source");
+
+        var items = reslist[0].getSourceArray();
+
+        test.equal(items.length, 4);
+        test.equal(items[0], null);
+        test.equal(items[1], null);
+        test.equal(items[2], null);
+        test.equal(items[3], "This is element 3");
+
+        items = reslist[0].getTargetArray();
+
+        test.equal(items.length, 4);
+        test.equal(items[0], null);
+        test.equal(items[1], null);
+        test.equal(items[2], null);
+        test.equal(items[3], "Este es 3");
+
+        test.done();
+    },
+
+    testXliffDeserializeWithComments: function(test) {
+        test.expect(18);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="string">\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '        <note>A very nice string</note>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>baby baby</source>\n' +
+                '        <note>Totally awesome.</note>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist[0].getSource(), "Asdf asdf");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getComment(), "A very nice string");
+        test.equal(reslist[0].getId(), "1");
+
+        test.equal(reslist[1].getSource(), "baby baby");
+        test.equal(reslist[1].getSourceLocale(), "en-US");
+        test.equal(reslist[1].getKey(), "huzzah");
+        test.equal(reslist[1].getPath(), "foo/bar/j.java");
+        test.equal(reslist[1].getProject(), "webapp");
+        test.equal(reslist[1].resType, "string");
+        test.equal(reslist[1].getComment(), "Totally awesome.");
+        test.equal(reslist[1].getId(), "2");
+
+        test.done();
+    },
+
+    testXliffDeserializeWithContext: function(test) {
+        test.expect(19);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="string" x-context="na na na">\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string" x-context="asdf">\n' +
+                '        <source>baby baby</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 2);
+
+        test.equal(reslist[0].getSource(), "Asdf asdf");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), "1");
+        test.equal(reslist[0].getContext(), "na na na");
+
+        test.equal(reslist[1].getSource(), "baby baby");
+        test.equal(reslist[1].getSourceLocale(), "en-US");
+        test.equal(reslist[1].getKey(), "huzzah");
+        test.equal(reslist[1].getPath(), "foo/bar/j.java");
+        test.equal(reslist[1].getProject(), "webapp");
+        test.equal(reslist[1].resType, "string");
+        test.equal(reslist[1].getId(), "2");
+        test.equal(reslist[1].getContext(), "asdf");
+
+        test.done();
+    },
+
+    testXliffDeserializeRealFile: function(test) {
+        test.expect(3);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        var fs = require("fs");
+
+        var str = fs.readFileSync("testfiles/test.xliff", "utf-8");
+
+        x.deserialize(str);
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 4);
+
+        test.done();
+    },
+
+    testXliffDeserializeEmptySource: function(test) {
+        test.expect(12);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="string" x-context="na na na">\n' +
+                '        <source></source>\n' +
+                '        <target>Baby Baby</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>baby baby</source>\n' +
+                '        <target>bebe bebe</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getSource(), "baby baby");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "huzzah");
+        test.equal(reslist[0].getPath(), "foo/bar/j.java");
+        test.equal(reslist[0].getProject(), "webapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), "2");
+
+        test.equal(reslist[0].getTarget(), "bebe bebe");
+        test.equal(reslist[0].getTargetLocale(), "fr-FR");
+
+        test.done();
+    },
+
+    testXliffDeserializeEmptyTarget: function(test) {
+        test.expect(19);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="androidapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="1" resname="foobar" restype="string">\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>baby baby</source>\n' +
+                '        <target></target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 2);
+
+        test.equal(reslist[0].getSource(), "Asdf asdf");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), "1");
+        test.equal(reslist[0].getOrigin(), "source");
+
+        test.equal(reslist[1].getSource(), "baby baby");
+        test.equal(reslist[1].getSourceLocale(), "en-US");
+        test.equal(reslist[1].getKey(), "huzzah");
+        test.equal(reslist[1].getPath(), "foo/bar/j.java");
+        test.equal(reslist[1].getProject(), "webapp");
+        test.equal(reslist[1].resType, "string");
+        test.equal(reslist[1].getId(), "2");
+        test.equal(reslist[1].getOrigin(), "source");
+
+        test.done();
+    },
+
+    testXliffDeserializeWithMrkTagInTarget: function(test) {
+        test.expect(12);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>baby baby</source><seg-source><mrk mtype="seg" mid="4">baby baby</mrk></seg-source><target><mrk mtype="seg" mid="4">bebe bebe</mrk></target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getSource(), "baby baby");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "huzzah");
+        test.equal(reslist[0].getPath(), "foo/bar/j.java");
+        test.equal(reslist[0].getProject(), "webapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), "2");
+
+        test.equal(reslist[0].getTarget(), "bebe bebe");
+        test.equal(reslist[0].getTargetLocale(), "fr-FR");
+
+        test.done();
+    },
+
+    testXliffDeserializeWithEmptyMrkTagInTarget: function(test) {
+        test.expect(11);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>baby baby</source><seg-source><mrk mtype="seg" mid="4">baby baby</mrk></seg-source><target><mrk mtype="seg" mid="4"/></target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getSource(), "baby baby");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "huzzah");
+        test.equal(reslist[0].getPath(), "foo/bar/j.java");
+        test.equal(reslist[0].getProject(), "webapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), "2");
+        test.equal(reslist[0].getOrigin(), "source");
+
+        test.done();
+    },
+
+    testXliffDeserializeWithMultipleMrkTagsInTargetEuro: function(test) {
+        test.expect(12);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>baby baby</source><seg-source><mrk mtype="seg" mid="4">baby baby</mrk></seg-source><target><mrk mtype="seg" mid="4">This is segment 1.</mrk> <mrk mtype="seg" mid="5">This is segment 2.</mrk> <mrk mtype="seg" mid="6">This is segment 3.</mrk></target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getSource(), "baby baby");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "huzzah");
+        test.equal(reslist[0].getPath(), "foo/bar/j.java");
+        test.equal(reslist[0].getProject(), "webapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), "2");
+
+        test.equal(reslist[0].getTarget(), "This is segment 1. This is segment 2. This is segment 3.");
+        test.equal(reslist[0].getTargetLocale(), "fr-FR");
+
+        test.done();
+    },
+
+    testXliffDeserializeWithMultipleMrkTagsInTargetAsian: function(test) {
+        test.expect(12);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="zh-Hans-CN" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>baby baby</source><seg-source><mrk mtype="seg" mid="4">baby baby</mrk></seg-source><target><mrk mtype="seg" mid="4">This is segment 1.</mrk> <mrk mtype="seg" mid="5">This is segment 2.</mrk> <mrk mtype="seg" mid="6">This is segment 3.</mrk></target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getSource(), "baby baby");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "huzzah");
+        test.equal(reslist[0].getPath(), "foo/bar/j.java");
+        test.equal(reslist[0].getProject(), "webapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), "2");
+
+        test.equal(reslist[0].getTarget(), "This is segment 1.This is segment 2.This is segment 3.");
+        test.equal(reslist[0].getTargetLocale(), "zh-Hans-CN");
+
+        test.done();
+    },
+
+    testXliffDeserializePreserveSourceWhitespace: function(test) {
+        test.expect(9);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="UI/AddAnotherButtonView.m" source-language="en-US" target-language="es-US" product-name="iosapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="196" resname="      Add Another" restype="string" datatype="x-objective-c">\n' +
+                '        <source>      Add Another</source>\n' +
+                '        <target>Añadir Otro</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getSource(), "      Add Another");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "      Add Another");
+        test.equal(reslist[0].getPath(), "UI/AddAnotherButtonView.m");
+        test.equal(reslist[0].getProject(), "iosapp");
+        test.equal(reslist[0].resType, "string");
+
+        test.done();
+    },
+
+    testXliffDeserializePreserveTargetWhitespace: function(test) {
+        test.expect(9);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="UI/AddAnotherButtonView.m" source-language="en-US" target-language="es-US" product-name="iosapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="196" resname="      Add Another" restype="string" datatype="x-objective-c">\n' +
+                '        <source>      Add Another</source>\n' +
+                '        <target> Añadir    Otro  </target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getTarget(), " Añadir    Otro  ");
+        test.equal(reslist[0].getTargetLocale(), "es-US");
+        test.equal(reslist[0].getKey(), "      Add Another");
+        test.equal(reslist[0].getPath(), "UI/AddAnotherButtonView.m");
+        test.equal(reslist[0].getProject(), "iosapp");
+        test.equal(reslist[0].resType, "string");
+
+        test.done();
+    },
+
+
+    testXliffTranslationUnitConstructor: function(test) {
+        test.expect(1);
+
+        var tu = new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp"
+        });
+
+        test.ok(tu);
+
+        test.done();
+    },
+
+    testXliffTranslationUnitConstructorEverythingCopied: function(test) {
+        test.expect(11);
+
+        var tu = new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment",
+            "flavor": "chocolate"
+        });
+
+        test.ok(tu);
+
+        test.equal(tu.source, "a");
+        test.equal(tu.sourceLocale, "en-US");
+        test.equal(tu.key, "foobar");
+        test.equal(tu.file, "/a/b/asdf.js");
+        test.equal(tu.project, "iosapp");
+        test.equal(tu.id, 2334);
+        test.equal(tu.origin, "source");
+        test.equal(tu.context, "asdfasdf");
+        test.equal(tu.comment, "this is a comment");
+        test.equal(tu.flavor, "chocolate");
+
+        test.done();
+    },
+
+    testXliffTranslationUnitConstructorMissingBasicProperties: function(test) {
+        test.expect(1);
+
+        test.throws(function() {
+            var tu = new TranslationUnit({
+                "source": "a",
+                "sourceLocale": "en-US",
+                "file": "/a/b/asdf.js",
+                "project": "iosapp",
+                "id": 2334,
+                "origin": "source",
+                "context": "asdfasdf",
+                "comment": "this is a comment"
+            });
+        });
+
+        test.done();
+    },
+
+    testXliffAddTranslationUnit: function(test) {
+        test.expect(10);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getSource(), "a");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "/a/b/asdf.js");
+        test.equal(reslist[0].getProject(), "iosapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), 2334);
+
+        test.done();
+    },
+
+    testXliffAddTranslationUnitMergeResources: function(test) {
+        test.expect(12);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "b",
+            "targetLocale": "fr-FR",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getSource(), "a");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getTarget(), "b");
+        test.equal(reslist[0].getTargetLocale(), "fr-FR");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "/a/b/asdf.js");
+        test.equal(reslist[0].getProject(), "iosapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), 2334);
+
+        test.done();
+    },
+
+    testXliffAddTranslationUnitAddMultipleUnits: function(test) {
+        test.expect(3);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "bababa",
+            "sourceLocale": "en-US",
+            "target": "ababab",
+            "targetLocale": "fr-FR",
+            "key": "asdf",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2333,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "b",
+            "targetLocale": "fr-FR",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        var units = x.getTranslationUnits();
+
+        test.ok(units);
+
+        test.equal(units.length, 2);
+
+        test.done();
+    },
+
+    testXliffAddTranslationUnitReplacePreviousUnit: function(test) {
+        test.expect(3);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "b",
+            "targetLocale": "fr-FR",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "ab",
+            "sourceLocale": "en-US",
+            "target": "ba",
+            "targetLocale": "fr-FR",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a new comment"
+        }));
+
+        var units = x.getTranslationUnits();
+
+        test.ok(units);
+
+        // should have merged them into 1 unit because the signature was the same
+        test.equal(units.length, 1);
+
+        test.done();
+    },
+
+    testXliffAddTranslationUnitRightContents: function(test) {
+        test.expect(15);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "b",
+            "targetLocale": "fr-FR",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "ab",
+            "sourceLocale": "en-US",
+            "target": "ba",
+            "targetLocale": "fr-FR",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a new comment"
+        }));
+
+        var units = x.getTranslationUnits();
+
+        test.ok(units);
+
+        test.equal(units.length, 1);
+
+        test.equal(units[0].source, "ab");
+        test.equal(units[0].sourceLocale, "en-US");
+        test.equal(units[0].target, "ba");
+        test.equal(units[0].targetLocale, "fr-FR");
+        test.equal(units[0].key, "foobar");
+        test.equal(units[0].file, "/a/b/asdf.js");
+        test.equal(units[0].project, "iosapp");
+        test.equal(units[0].id, 2334);
+        test.equal(units[0].resType, "string");
+        test.equal(units[0].origin, "source");
+        test.equal(units[0].context, "asdfasdf");
+        test.equal(units[0].comment, "this is a new comment");
+
+        test.done();
+    },
+
+    testXliffAddTranslationUnitRightResourceTypesRegularString: function(test) {
+        test.expect(4);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "b",
+            "targetLocale": "fr-FR",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType": "string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment",
+            "datatype": "javascript"
+        }));
+
+        var resources = x.getResources();
+
+        test.ok(resources);
+
+        test.equal(resources.length, 1);
+
+        test.ok(resources[0] instanceof ResourceString);
+
+        test.done();
+    },
+
+    testXliffAddTranslationUnitRightResourceTypesContextString: function(test) {
+        test.expect(5);
+
+        ResourceFactory.registerDataType("x-android-resource", "string", ContextResourceString);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "ba",
+            "targetLocale": "fr-FR",
+            "key": "foobar",
+            "file": "/a/b/asdf.xml",
+            "project": "androidapp",
+            "id": 2334,
+            "resType":"string",
+            "comment": "this is a comment",
+            "datatype": "x-android-resource",
+            "flavor": "chocolate"
+        }));
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "baa",
+            "targetLocale": "fr-FR",
+            "key": "foobar",
+            "file": "/a/b-x/asdf.xml",
+            "project": "androidapp",
+            "id": 2334,
+            "resType": "string",
+            "context": "x",
+            "comment": "this is a new comment",
+            "datatype": "x-android-resource",
+            "flavor": "chocolate"
+        }));
+
+        var resources = x.getResources();
+
+        test.ok(resources);
+
+        test.equal(resources.length, 2);
+
+        test.ok(resources[0] instanceof ContextResourceString);
+        test.ok(resources[1] instanceof ContextResourceString);
+
+        test.done();
+    },
+
+    testXliffAddTranslationUnitReplaceSourceOnlyUnit: function(test) {
+        test.expect(3);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType": "string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "b",
+            "targetLocale": "fr-FR",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        var units = x.getTranslationUnits();
+
+        test.ok(units);
+
+        // should have merged them into 1 unit because the signature was the same
+        test.equal(units.length, 1);
+
+        test.done();
+    },
+
+    testXliffAddTranslationUnitDifferentPathsRightTypes: function(test) {
+        test.expect(5);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        ResourceFactory.registerDataType("x-xib", "string", IosLayoutResourceString);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "foo",
+            "targetLocale": "de-DE",
+            "key": "foobar",
+            "file": "a/b/asdf.xib",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "origin": "target",
+            "comment": "this is a comment",
+            "datatype": "x-xib"
+        }));
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "foo",
+            "targetLocale": "de-DE",
+            "key": "foobar",
+            "file": "a/b/asdf~ipad.xib",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "origin": "target",
+            "comment": "this is a comment",
+            "datatype": "x-xib"
+        }));
+
+        var resources = x.getResources();
+
+        test.ok(resources);
+
+        test.equal(resources.length, 2);
+
+        test.ok(resources[0] instanceof IosLayoutResourceString);
+        test.ok(resources[1] instanceof IosLayoutResourceString);
+
+        test.done();
+    },
+
+    testXliffAddTranslationUnitDifferentPaths: function(test) {
+        test.expect(23);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        ResourceFactory.registerDataType("x-xib", "string", IosLayoutResourceString);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "foo",
+            "targetLocale": "de-DE",
+            "key": "foobar",
+            "file": "a/b/asdf.xib",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "comment": "this is a comment",
+            "datatype": "x-xib"
+        }));
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "foo",
+            "targetLocale": "de-DE",
+            "key": "foobar",
+            "file": "a/b/asdf~ipad.xib",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "comment": "this is a comment",
+            "datatype": "x-xib"
+        }));
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 2);
+
+        test.equal(reslist[0].getSource(), "a");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getTarget(), "foo");
+        test.equal(reslist[0].getTargetLocale(), "de-DE");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "a/b/asdf.xib");
+        test.equal(reslist[0].getProject(), "iosapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].datatype, "x-xib");
+        test.equal(reslist[0].getId(), 2334);
+
+        test.equal(reslist[1].getSource(), "a");
+        test.equal(reslist[1].getSourceLocale(), "en-US");
+        test.equal(reslist[1].getTarget(), "foo");
+        test.equal(reslist[1].getTargetLocale(), "de-DE");
+        test.equal(reslist[1].getKey(), "foobar");
+        test.equal(reslist[1].getPath(), "a/b/asdf~ipad.xib");
+        test.equal(reslist[1].getProject(), "iosapp");
+        test.equal(reslist[1].resType, "string");
+        test.equal(reslist[1].datatype, "x-xib");
+        test.equal(reslist[1].getId(), 2334);
+
+        test.done();
+    },
+
+    testXliffSerializeWithTranslationUnits: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "bababa",
+            "sourceLocale": "en-US",
+            "target": "ababab",
+            "targetLocale": "fr-FR",
+            "key": "asdf",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2333,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "b",
+            "targetLocale": "fr-FR",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        diff(x.serialize(),
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="/a/b/asdf.js" source-language="en-US" target-language="fr-FR" product-name="iosapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2333" resname="asdf" restype="string" x-context="asdfasdf">\n' +
+                '        <source>bababa</source>\n' +
+                '        <target>ababab</target>\n' +
+                '        <note>this is a comment</note>\n' +
+                '      </trans-unit>\n' +
+                '      <trans-unit id="2334" resname="foobar" restype="string" x-context="asdfasdf">\n' +
+                '        <source>a</source>\n' +
+                '        <target>b</target>\n' +
+                '        <note>this is a comment</note>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        test.equal(x.serialize(),
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="/a/b/asdf.js" source-language="en-US" target-language="fr-FR" product-name="iosapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2333" resname="asdf" restype="string" x-context="asdfasdf">\n' +
+                '        <source>bababa</source>\n' +
+                '        <target>ababab</target>\n' +
+                '        <note>this is a comment</note>\n' +
+                '      </trans-unit>\n' +
+                '      <trans-unit id="2334" resname="foobar" restype="string" x-context="asdfasdf">\n' +
+                '        <source>a</source>\n' +
+                '        <target>b</target>\n' +
+                '        <note>this is a comment</note>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        test.done();
+    },
+
+    testXliffSerializeWithTranslationUnitsDifferentLocales: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "bababa",
+            "sourceLocale": "en-US",
+            "target": "ababab",
+            "targetLocale": "fr-FR",
+            "key": "asdf",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2333,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "b",
+            "targetLocale": "de-DE",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        var actual = x.serialize();
+        var expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="/a/b/asdf.js" source-language="en-US" target-language="de-DE" product-name="iosapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2334" resname="foobar" restype="string" x-context="asdfasdf">\n' +
+                '        <source>a</source>\n' +
+                '        <target>b</target>\n' +
+                '        <note>this is a comment</note>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '  <file original="/a/b/asdf.js" source-language="en-US" target-language="fr-FR" product-name="iosapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2333" resname="asdf" restype="string" x-context="asdfasdf">\n' +
+                '        <source>bababa</source>\n' +
+                '        <target>ababab</target>\n' +
+                '        <note>this is a comment</note>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testXliffAddResourcesWithInstances: function(test) {
+        test.expect(9);
+
+        const x = new Xliff({
+            allowDups: true
+        });
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp"
+        });
+
+        var res2 = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp",
+            comment: "special translators note"
+        });
+        res.addInstance(res2);
+
+        x.addResource(res);
+
+        var reslist = x.getResources({
+            reskey: "foobar"
+        });
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+        test.equal(reslist[0].getSource(), "Asdf asdf");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "webapp");
+        test.ok(!reslist[0].getComment());
+
+        test.done();
+    },
+
+    testXliffAddMultipleResourcesAddInstances: function(test) {
+        test.expect(17);
+
+        const x = new Xliff({
+            allowDups: true
+        });
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        // this one has the same source, locale, key, and file
+        // so it should create an instance of the first one
+        res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            comment: "blah blah blah",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        var reslist = x.getResources({
+            reskey: "foobar"
+        });
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+        test.equal(reslist[0].getSource(), "Asdf asdf");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "webapp");
+        test.ok(!reslist[0].getComment());
+
+        var instances = reslist[0].getInstances();
+        test.ok(instances);
+        test.equal(instances.length, 1);
+
+        test.equal(instances[0].getSource(), "Asdf asdf");
+        test.equal(instances[0].getSourceLocale(), "en-US");
+        test.equal(instances[0].getKey(), "foobar");
+        test.equal(instances[0].getPath(), "foo/bar/asdf.java");
+        test.equal(instances[0].getProject(), "webapp");
+        test.equal(instances[0].getComment(), "blah blah blah");
+
+        test.done();
+    },
+
+    testXliffSerializeWithResourcesWithInstances: function(test) {
+        test.expect(2);
+
+        const x = new Xliff({
+            allowDups: true
+        });
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        // this one has the same source, locale, key, and file
+        // so it should create an instance of the first one
+        res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            comment: "blah blah blah",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        var expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="1.2">\n' +
+            '  <file original="foo/bar/asdf.java" source-language="en-US" product-name="webapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="1" resname="foobar" restype="string" datatype="plaintext">\n' +
+            '        <source>Asdf asdf</source>\n' +
+            '      </trans-unit>\n' +
+            '      <trans-unit id="2" resname="foobar" restype="string" datatype="plaintext">\n' +
+            '        <source>Asdf asdf</source>\n' +
+            '        <note>blah blah blah</note>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        var actual = x.serialize();
+        diff(actual, expected);
+
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testXliffSerializeWithTranslationUnitsWithInstances: function(test) {
+        test.expect(2);
+
+        const x = new Xliff({
+            allowDups: true
+        });
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "bababa",
+            "sourceLocale": "en-US",
+            "target": "ababab",
+            "targetLocale": "fr-FR",
+            "key": "asdf",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2333,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "bababa",
+            "sourceLocale": "en-US",
+            "target": "ababab",
+            "targetLocale": "fr-FR",
+            "key": "asdf",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a different comment"
+        }));
+
+        var expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="1.2">\n' +
+            '  <file original="/a/b/asdf.js" source-language="en-US" target-language="fr-FR" product-name="iosapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="2333" resname="asdf" restype="string" x-context="asdfasdf">\n' +
+            '        <source>bababa</source>\n' +
+            '        <target>ababab</target>\n' +
+            '        <note>this is a comment</note>\n' +
+            '      </trans-unit>\n' +
+            '      <trans-unit id="2334" resname="asdf" restype="string" x-context="asdfasdf">\n' +
+            '        <source>bababa</source>\n' +
+            '        <target>ababab</target>\n' +
+            '        <note>this is a different comment</note>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        var actual = x.serialize();
+        diff(actual, expected);
+
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testXliffDeserializeCreateInstances: function(test) {
+        test.expect(21);
+
+        const x = new Xliff({
+            allowDups: true
+        });
+        test.ok(x);
+
+        x.deserialize(
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="1.2">\n' +
+            '  <file original="/a/b/asdf.js" source-language="en-US" target-language="fr-FR" product-name="iosapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="2333" resname="asdf" restype="string" x-context="asdfasdf">\n' +
+            '        <source>bababa</source>\n' +
+            '        <target>ababab</target>\n' +
+            '        <note>this is a comment</note>\n' +
+            '      </trans-unit>\n' +
+            '      <trans-unit id="2334" resname="asdf" restype="string" x-context="asdfasdf">\n' +
+            '        <source>bababa</source>\n' +
+            '        <target>ababab</target>\n' +
+            '        <note>this is a different comment</note>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getTarget(), "ababab");
+        test.equal(reslist[0].getTargetLocale(), "fr-FR");
+        test.equal(reslist[0].getKey(), "asdf");
+        test.equal(reslist[0].getPath(), "/a/b/asdf.js");
+        test.equal(reslist[0].getProject(), "iosapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].context, "asdfasdf");
+        test.equal(reslist[0].comment, "this is a comment");
+
+        var instances = reslist[0].getInstances();
+        test.ok(instances);
+        test.equal(instances.length, 1);
+
+        test.equal(instances[0].getTarget(), "ababab");
+        test.equal(instances[0].getTargetLocale(), "fr-FR");
+        test.equal(instances[0].getKey(), "asdf");
+        test.equal(instances[0].getPath(), "/a/b/asdf.js");
+        test.equal(instances[0].getProject(), "iosapp");
+        test.equal(instances[0].resType, "string");
+        test.equal(instances[0].context, "asdfasdf");
+        test.equal(instances[0].comment, "this is a different comment");
+
+        test.done();
+    },
+
+    testXliffDeserializeStillAcceptsAnnotatesAttr: function(test) {
+        test.expect(21);
+
+        const x = new Xliff({
+            allowDups: true
+        });
+        test.ok(x);
+
+        x.deserialize(
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="1.2">\n' +
+            '  <file original="/a/b/asdf.js" source-language="en-US" target-language="fr-FR" product-name="iosapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="2333" resname="asdf" restype="string" x-context="asdfasdf">\n' +
+            '        <source>bababa</source>\n' +
+            '        <target>ababab</target>\n' +
+            '        <note annotates="source">this is a comment</note>\n' +
+            '      </trans-unit>\n' +
+            '      <trans-unit id="2334" resname="asdf" restype="string" x-context="asdfasdf">\n' +
+            '        <source>bababa</source>\n' +
+            '        <target>ababab</target>\n' +
+            '        <note annotates="source">this is a different comment</note>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getTarget(), "ababab");
+        test.equal(reslist[0].getTargetLocale(), "fr-FR");
+        test.equal(reslist[0].getKey(), "asdf");
+        test.equal(reslist[0].getPath(), "/a/b/asdf.js");
+        test.equal(reslist[0].getProject(), "iosapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].context, "asdfasdf");
+        test.equal(reslist[0].comment, "this is a comment");
+
+        var instances = reslist[0].getInstances();
+        test.ok(instances);
+        test.equal(instances.length, 1);
+
+        test.equal(instances[0].getTarget(), "ababab");
+        test.equal(instances[0].getTargetLocale(), "fr-FR");
+        test.equal(instances[0].getKey(), "asdf");
+        test.equal(instances[0].getPath(), "/a/b/asdf.js");
+        test.equal(instances[0].getProject(), "iosapp");
+        test.equal(instances[0].resType, "string");
+        test.equal(instances[0].context, "asdfasdf");
+        test.equal(instances[0].comment, "this is a different comment");
+
+        test.done();
+    }
+*/
+};

--- a/test/testXliff20.js
+++ b/test/testXliff20.js
@@ -108,42 +108,196 @@ export const testXliff20 = {
 
         test.done();
     },
-/*
-    testXliff20AddResource: function(test) {
+
+    testXliff20AddTranslationUnit: function(test) {
         test.expect(11);
 
-        var x = new Xliff({version: "2.0"});
+        const x = new Xliff({version: 2.0});
         test.ok(x);
 
-        var res = new ResourceString({
+        let tu = new TranslationUnit({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            autoKey: false,
+            file: "foo/bar/asdf.java",
+            project: "webapp",
+            resType: "string",
             state: "new",
-            context: "asdf",
-            comment: "this is a comment",
-            project: "webapp"
+            comment: "This is a comment",
+            datatype: "java"
         });
 
-        x.addResource(res);
+        x.addTranslationUnit(tu);
 
-        var reslist = x.getResources({
-            reskey: "foobar"
+        const tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+        test.equal(tulist[0].source, "Asdf asdf");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "foobar");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].state, "new");
+        test.equal(tulist[0].comment, "This is a comment");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].datatype, "java");
+
+        test.done();
+    },
+
+    testXliff20AddTranslationUnitMultiple: function(test) {
+        test.expect(19);
+
+        const x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        let tu = new TranslationUnit({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            file: "foo/bar/asdf.java",
+            project: "webapp",
+            resType: "string",
+            state: "new",
+            comment: "This is a comment",
+            datatype: "java"
         });
 
-        test.ok(reslist);
+        x.addTranslationUnit(tu);
 
-        test.equal(reslist.length, 1);
-        test.equal(reslist[0].getSource(), "Asdf asdf");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getState(), "new");
-        test.equal(reslist[0].getContext(), "asdf");
-        test.equal(reslist[0].getComment(), "this is a comment");
-        test.equal(reslist[0].getProject(), "webapp");
+        tu = new TranslationUnit({
+            source: "foobar",
+            sourceLocale: "en-US",
+            key: "asdf",
+            file: "x.java",
+            project: "webapp",
+            resType: "array",
+            state: "translated",
+            comment: "No comment",
+            datatype: "javascript"
+        });
+
+        x.addTranslationUnit(tu);
+
+        const tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 2);
+        test.equal(tulist[0].source, "Asdf asdf");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "foobar");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].state, "new");
+        test.equal(tulist[0].comment, "This is a comment");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].datatype, "java");
+
+        test.equal(tulist[1].source, "foobar");
+        test.equal(tulist[1].sourceLocale, "en-US");
+        test.equal(tulist[1].key, "asdf");
+        test.equal(tulist[1].file, "x.java");
+        test.equal(tulist[1].state, "translated");
+        test.equal(tulist[1].comment, "No comment");
+        test.equal(tulist[1].project, "webapp");
+        test.equal(tulist[1].datatype, "javascript");
+
+        test.done();
+    },
+
+    testXliff20AddTranslationUnitAddSameTUTwice: function(test) {
+        test.expect(11);
+
+        const x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        let tu = new TranslationUnit({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            file: "foo/bar/asdf.java",
+            project: "webapp",
+            resType: "string",
+            state: "new",
+            comment: "This is a comment",
+            datatype: "java"
+        });
+
+        x.addTranslationUnit(tu);
+        x.addTranslationUnit(tu); // second time should not add anything
+
+        const tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+        test.equal(tulist[0].source, "Asdf asdf");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "foobar");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].state, "new");
+        test.equal(tulist[0].comment, "This is a comment");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].datatype, "java");
+
+        test.done();
+    },
+
+    testXliff20AddTranslationUnits: function(test) {
+        test.expect(19);
+
+        const x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        
+        x.addTranslationUnits([
+            new TranslationUnit({
+                source: "Asdf asdf",
+                sourceLocale: "en-US",
+                key: "foobar",
+                file: "foo/bar/asdf.java",
+                project: "webapp",
+                resType: "string",
+                state: "new",
+                comment: "This is a comment",
+                datatype: "java"
+            }),
+            new TranslationUnit({
+                source: "foobar",
+                sourceLocale: "en-US",
+                key: "asdf",
+                file: "x.java",
+                project: "webapp",
+                resType: "array",
+                state: "translated",
+                comment: "No comment",
+                datatype: "javascript"
+            })
+        ]);
+
+        const tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 2);
+        test.equal(tulist[0].source, "Asdf asdf");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "foobar");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].state, "new");
+        test.equal(tulist[0].comment, "This is a comment");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].datatype, "java");
+
+        test.equal(tulist[1].source, "foobar");
+        test.equal(tulist[1].sourceLocale, "en-US");
+        test.equal(tulist[1].key, "asdf");
+        test.equal(tulist[1].file, "x.java");
+        test.equal(tulist[1].state, "translated");
+        test.equal(tulist[1].comment, "No comment");
+        test.equal(tulist[1].project, "webapp");
+        test.equal(tulist[1].datatype, "javascript");
 
         test.done();
     },
@@ -151,354 +305,73 @@ export const testXliff20 = {
     testXliff20Size: function(test) {
         test.expect(3);
 
-        var x = new Xliff({version: "2.0"});
+        const x = new Xliff({version: 2.0});
         test.ok(x);
-
-        var res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            autoKey: false,
-            state: "new",
-            context: "asdf",
-            comment: "this is a comment",
-            project: "webapp"
-        });
 
         test.equal(x.size(), 0);
 
-        x.addResource(res);
-
-        test.equal(x.size(), 1);
-
-        test.done();
-    },
-
-    testXliff20AddMultipleResources: function(test) {
-        test.expect(8);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        var res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        res = new ResourceString({
-            source: "baby baby",
-            sourceLocale: "en-US",
-            key: "huzzah",
-            pathName: "foo/bar/j.java",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        var reslist = x.getResources({
-            reskey: "foobar"
-        });
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-        test.equal(reslist[0].getSource(), "Asdf asdf");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "webapp");
-
-        test.done();
-    },
-
-    testXliff20AddMultipleResourcesRightSize: function(test) {
-        test.expect(3);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-        test.equal(x.size(), 0);
-
-        var res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        res = new ResourceString({
-            source: "baby baby",
-            sourceLocale: "en-US",
-            key: "huzzah",
-            pathName: "foo/bar/j.java",
-            project: "webapp"
-        });
-
-        x.addResource(res);
+        x.addTranslationUnits([
+            new TranslationUnit({
+                source: "Asdf asdf",
+                sourceLocale: "en-US",
+                key: "foobar",
+                file: "foo/bar/asdf.java",
+                project: "webapp",
+                resType: "string",
+                state: "new",
+                comment: "This is a comment",
+                datatype: "java"
+            }),
+            new TranslationUnit({
+                source: "foobar",
+                sourceLocale: "en-US",
+                key: "asdf",
+                file: "x.java",
+                project: "webapp",
+                resType: "array",
+                state: "translated",
+                comment: "No comment",
+                datatype: "javascript"
+            })
+        ]);
 
         test.equal(x.size(), 2);
 
         test.done();
     },
 
-    testXliff20AddMultipleResourcesOverwrite: function(test) {
-        test.expect(9);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        var res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        // this one has the same source, locale, key, and file
-        // so it should overwrite the one above
-        res = new ResourceString({
-            source: "baby baby",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            comment: "blah blah blah",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        var reslist = x.getResources({
-            reskey: "foobar"
-        });
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-        test.equal(reslist[0].getSource(), "baby baby");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "webapp");
-        test.equal(reslist[0].getComment(), "blah blah blah");
-
-        test.done();
-    },
-
-    testXliff20AddMultipleResourcesOverwriteRightSize: function(test) {
-        test.expect(4);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        test.equal(x.size(), 0);
-
-        var res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        test.equal(x.size(), 1);
-
-        // this one has the same source, locale, key, and file
-        // so it should overwrite the one above
-        res = new ResourceString({
-            source: "baby baby",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            comment: "blah blah blah",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        test.equal(x.size(), 1);
-
-        test.done();
-    },
-
-    testXliff20AddMultipleResourcesNoOverwrite: function(test) {
-        test.expect(13);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        var res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        // this one has a different locale
-        // so it should not overwrite the one above
-        res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "fr-FR",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            comment: "blah blah blah",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        var reslist = x.getResources({
-            reskey: "foobar"
-        });
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 2);
-
-        test.equal(reslist[0].getSource(), "Asdf asdf");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.ok(!reslist[0].getComment());
-
-        test.equal(reslist[1].getSource(), "Asdf asdf");
-        test.equal(reslist[1].getSourceLocale(), "fr-FR");
-        test.equal(reslist[1].getKey(), "foobar");
-        test.equal(reslist[1].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[1].getComment(), "blah blah blah");
-
-        test.done();
-    },
-
-    testXliff20AddResourceDontAddSourceLocaleAsTarget: function(test) {
+    testXliff20SerializeSourceOnly: function(test) {
         test.expect(2);
 
-        var x = new Xliff({
-            version: "2.0",
-            sourceLocale: "en-US"
-        });
+        const x = new Xliff({version: 2.0});
         test.ok(x);
 
-        var res = new ResourceString({
+        const tu = new TranslationUnit({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        // should not add this one
-        res = new ResourceString({
-            source: "baby baby",
-            target: "babes babes",
-            targetLocale: "en-US",
-            key: "huzzah",
-            pathName: "foo/bar/j.java",
+            file: "foo/bar/asdf.java",
             project: "webapp",
-            origin: "target"
-        });
+            resType: "string",
+            state: "new",
+            comment: "This is a comment",
+            datatype: "java"
+        })
 
-        x.addResource(res);
+        x.addTranslationUnit(tu);
 
-        test.equal(x.size(), 1);
-
-        test.done();
-    },
-
-    testXliff20GetResourcesMultiple: function(test) {
-        test.expect(11);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        var res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp",
-            origin: "source"
-        });
-
-        x.addResource(res);
-
-        res = new ResourceString({
-            source: "baby baby",
-            sourceLocale: "en-US",
-            key: "huzzah",
-            pathName: "foo/bar/j.java",
-            project: "webapp",
-            origin: "origin"
-        });
-
-        x.addResource(res);
-
-        var reslist = x.getResources({
-            sourceLocale: "en-US"
-        });
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 2);
-
-        test.equal(reslist[0].getSource(), "Asdf asdf");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-
-        test.equal(reslist[1].getSource(), "baby baby");
-        test.equal(reslist[1].getSourceLocale(), "en-US");
-        test.equal(reslist[1].getKey(), "huzzah");
-        test.equal(reslist[1].getPath(), "foo/bar/j.java");
-
-        test.done();
-    },
-
-    testXliff20SerializeWithContext: function(test) {
-        test.expect(2);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        var res = new ContextResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            target: "gutver",
-            targetLocale: "nl-NL",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            context: "foobar"
-        });
-
-        x.addResource(res);
-
-        var actual = x.serialize();
-        var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
-            '<xliff version="2.0" srcLang="en-US" trgLang="nl-NL" xmlns:l="http://ilib-js.com/loctool">\n' +
-            '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-            '    <group id="group_1" name="plaintext">\n' +
-            '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext" l:context="foobar">\n' +
+        let actual = x.serialize();
+        let expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="2.0" srcLang="en-US" xmlns:l="http://ilib-js.com/loctool">\n' +
+            '  <file original="foo/bar/asdf.java" l:project="webapp">\n' +
+            '    <group id="group_1" name="java">\n' +
+            '      <unit id="1" name="foobar" type="res:string" l:datatype="java">\n' +
+            '        <notes>\n' +
+            '          <note appliesTo="source">This is a comment</note>\n' +
+            '        </notes>\n' +
             '        <segment>\n' +
             '          <source>Asdf asdf</source>\n' +
-            '          <target>gutver</target>\n' +
             '        </segment>\n' +
             '      </unit>\n' +
             '    </group>\n' +
@@ -510,111 +383,41 @@ export const testXliff20 = {
         test.done();
     },
 
-    testXliff20SerializeWithSourceOnly: function(test) {
+    testXliff20SerializeFull: function(test) {
         test.expect(2);
 
-        var x = new Xliff({version: "2.0"});
+        const x = new Xliff({version: 2.0});
         test.ok(x);
 
-        var res = new ContextResourceString({
+        const tu = new TranslationUnit({
             source: "Asdf asdf",
             sourceLocale: "en-US",
+            target: "bam bam",
+            targetLocale: "de-DE",
             key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            targetLocale: "de-DE"
-        });
-
-        x.addResource(res);
-
-        res = new ContextResourceString({
-            source: "baby baby",
-            sourceLocale: "en-US",
-            key: "huzzah",
-            pathName: "foo/bar/j.java",
+            file: "foo/bar/asdf.java",
             project: "webapp",
-            targetLocale: "de-DE"
-        });
+            resType: "string",
+            state: "new",
+            comment: "This is a comment",
+            datatype: "java"
+        })
 
-        x.addResource(res);
+        x.addTranslationUnit(tu);
 
-        var actual = x.serialize();
-        var expected =
+        let actual = x.serialize();
+        let expected =
             '<?xml version="1.0" encoding="utf-8"?>\n' +
             '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
-            '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-            '    <group id="group_1" name="plaintext">\n' +
-            '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
+            '  <file original="foo/bar/asdf.java" l:project="webapp">\n' +
+            '    <group id="group_1" name="java">\n' +
+            '      <unit id="1" name="foobar" type="res:string" l:datatype="java">\n' +
+            '        <notes>\n' +
+            '          <note appliesTo="source">This is a comment</note>\n' +
+            '        </notes>\n' +
             '        <segment>\n' +
             '          <source>Asdf asdf</source>\n' +
-            '        </segment>\n' +
-            '      </unit>\n' +
-            '    </group>\n' +
-            '  </file>\n' +
-            '  <file original="foo/bar/j.java" l:project="webapp">\n' +
-            '    <group id="group_2" name="plaintext">\n' +
-            '      <unit id="2" name="huzzah" type="res:string" l:datatype="plaintext">\n' +
-            '        <segment>\n' +
-            '          <source>baby baby</source>\n' +
-            '        </segment>\n' +
-            '      </unit>\n' +
-            '    </group>\n' +
-            '  </file>\n' +
-            '</xliff>';
-
-        diff(actual, expected);
-        test.equal(actual, expected);
-        test.done();
-
-
-    },
-
-    testXliff20SerializediffrentFileSampePrj: function(test) {
-        test.expect(2);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        var res = new ContextResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            targetLocale: "de-DE"
-        });
-
-        x.addResource(res);
-
-        res = new ContextResourceString({
-            source: "baby baby",
-            sourceLocale: "en-US",
-            key: "huzzah",
-            pathName: "foo/bar/j.java",
-            project: "androidapp",
-            targetLocale: "de-DE"
-        });
-
-        x.addResource(res);
-
-        var actual = x.serialize();
-        var expected =
-            '<?xml version="1.0" encoding="utf-8"?>\n' +
-            '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
-            '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-            '    <group id="group_1" name="plaintext">\n' +
-            '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
-            '        <segment>\n' +
-            '          <source>Asdf asdf</source>\n' +
-            '        </segment>\n' +
-            '      </unit>\n' +
-            '    </group>\n' +
-            '  </file>\n' +
-            '  <file original="foo/bar/j.java" l:project="androidapp">\n' +
-            '    <group id="group_2" name="plaintext">\n' +
-            '      <unit id="2" name="huzzah" type="res:string" l:datatype="plaintext">\n' +
-            '        <segment>\n' +
-            '          <source>baby baby</source>\n' +
+            '          <target state="new">bam bam</target>\n' +
             '        </segment>\n' +
             '      </unit>\n' +
             '    </group>\n' +
@@ -626,182 +429,139 @@ export const testXliff20 = {
         test.done();
     },
 
-    testXliff20SerializeSampeFilesPrj: function(test) {
+    testXliff20SerializeWithSourceAndTargetAndComment: function(test) {
         test.expect(2);
 
-        var x = new Xliff({version: "2.0"});
+        const x = new Xliff({version: 2.0});
         test.ok(x);
 
-        var res = new ContextResourceString({
+        let tu = new TranslationUnit({
             source: "Asdf asdf",
             sourceLocale: "en-US",
+            target: "foobarfoo",
+            targetLocale: "de-DE",
             key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            targetLocale: "de-DE"
-        });
-
-        x.addResource(res);
-
-        res = new ContextResourceString({
-            source: "baby baby",
-            sourceLocale: "en-US",
-            key: "huzzah",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            targetLocale: "de-DE"
-        });
-
-        x.addResource(res);
-
-        var actual = x.serialize();
-        var expected =
-            '<?xml version="1.0" encoding="utf-8"?>\n' +
-            '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
-            '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-            '    <group id="group_1" name="plaintext">\n' +
-            '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
-            '        <segment>\n' +
-            '          <source>Asdf asdf</source>\n' +
-            '        </segment>\n' +
-            '      </unit>\n' +
-            '      <unit id="2" name="huzzah" type="res:string" l:datatype="plaintext">\n' +
-            '        <segment>\n' +
-            '          <source>baby baby</source>\n' +
-            '        </segment>\n' +
-            '      </unit>\n' +
-            '    </group>\n' +
-            '  </file>\n' +
-            '</xliff>';
-
-        diff(actual, expected);
-        test.equal(actual, expected);
-        test.done();
-    },
-
-    testXliff20SerializeWithSourceOnlyFilterOutWrongLocales: function(test) {
-        test.expect(2);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        var res = new ContextResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            targetLocale: "de-DE"
-        });
-
-        x.addResource(res);
-
-        // should be filtered out because of the different target locale
-        res = new ContextResourceString({
-            source: "baby baby",
-            sourceLocale: "en-US",
-            key: "huzzah",
-            pathName: "foo/bar/j.java",
+            file: "foo/bar/asdf.java",
             project: "webapp",
-            targetLocale: "fr-FR"
+            comment: "foobar is where it's at!",
+            datatype: "plaintext"
         });
 
-        x.addResource(res);
+        x.addTranslationUnit(tu);
 
-        var actual = x.serialize();
-        var expected =
-            '<?xml version="1.0" encoding="utf-8"?>\n' +
-            '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
-            '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-            '    <group id="group_1" name="plaintext">\n' +
-            '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
-            '        <segment>\n' +
-            '          <source>Asdf asdf</source>\n' +
-            '        </segment>\n' +
-            '      </unit>\n' +
-            '    </group>\n' +
-            '  </file>\n' +
-            '</xliff>';
-
-        diff(actual, expected);
-        test.equal(actual, expected);
-        test.done();
-    },
-
-    testXliff20SerializeWithFlavors: function(test) {
-        test.expect(2);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        var res = new ContextResourceString({
-            source: "Asdf asdf",
+        tu = new TranslationUnit({
+            source: "baby baby",
             sourceLocale: "en-US",
-            target: "gutver",
-            targetLocale: "nl-NL",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            origin: "source",
-            flavor: "chocolate"
+            target: "bebe bebe",
+            targetLocale: "de-DE",
+            key: "huzzah",
+            file: "foo/bar/j.java",
+            project: "webapp",
+            comment: "come & enjoy it with us",
+            datatype: "plaintext"
         });
 
-        x.addResource(res);
+        x.addTranslationUnit(tu);
 
-        var actual = x.serialize();
-        var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
-            '<xliff version="2.0" srcLang="en-US" trgLang="nl-NL" xmlns:l="http://ilib-js.com/loctool">\n' +
-            '  <file original="foo/bar/asdf.java" l:project="androidapp" l:flavor="chocolate">\n' +
-            '    <group id="group_1" name="plaintext">\n' +
-            '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
-            '        <segment>\n' +
-            '          <source>Asdf asdf</source>\n' +
-            '          <target>gutver</target>\n' +
-            '        </segment>\n' +
-            '      </unit>\n' +
-            '    </group>\n' +
-            '  </file>\n' +
-            '</xliff>';
+        let expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="webapp">\n' +
+                '    <group id="group_1" name="plaintext">\n' +
+                '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
+                '        <notes>\n' +
+                '          <note appliesTo="source">foobar is where it\'s at!</note>\n' +
+                '        </notes>\n' +
+                '        <segment>\n' +
+                '          <source>Asdf asdf</source>\n' +
+                '          <target>foobarfoo</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <group id="group_2" name="plaintext">\n' +
+                '      <unit id="2" name="huzzah" type="res:string" l:datatype="plaintext">\n' +
+                '        <notes>\n' +
+                '          <note appliesTo="source">come &amp; enjoy it with us</note>\n' +
+                '        </notes>\n' +
+                '        <segment>\n' +
+                '          <source>baby baby</source>\n' +
+                '          <target>bebe bebe</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '</xliff>';
+
+        let actual = x.serialize();
 
         diff(actual, expected);
         test.equal(actual, expected);
+
         test.done();
     },
 
     testXliff20SerializeWithSourceOnlyAndPlurals: function(test) {
         test.expect(2);
 
-        var x = new Xliff({version: "2.0"});
+        const x = new Xliff({version: 2.0});
         test.ok(x);
 
-        var res = new ContextResourceString({
+        let tu = new TranslationUnit({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             key: "foobar",
-            pathName: "foo/bar/asdf.java",
+            file: "foo/bar/asdf.java",
+            datatype: "plaintext",
             project: "androidapp",
-            targetLocale: "de-DE"
+            targetLocale: "de-DE",
+            resType: "string"
         });
 
-        x.addResource(res);
+        x.addTranslationUnit(tu);
 
-        res = new ResourcePlural({
-            sourceStrings: {
-                "zero": "0",
-                "one": "1",
-                "few": "few"
-            },
-            sourceLocale: "en-US",
-            key: "huzzah",
-            pathName: "foo/bar/j.java",
-            project: "webapp",
-            targetLocale: "de-DE"
-        });
+        x.addTranslationUnits([
+            new TranslationUnit({
+                source: "0",
+                sourceLocale: "en-US",
+                key: "huzzah",
+                file: "foo/bar/j.java",
+                project: "webapp",
+                targetLocale: "de-DE",
+                datatype: "x-android-resource",
+                quantity: "zero",
+                resType: "plural",
+                comment: '{"pluralForm":"zero","pluralFormOther":"huzzah"}'
+            }),
+            new TranslationUnit({
+                source: "1",
+                sourceLocale: "en-US",
+                key: "huzzah",
+                file: "foo/bar/j.java",
+                project: "webapp",
+                targetLocale: "de-DE",
+                datatype: "x-android-resource",
+                quantity: "one",
+                resType: "plural",
+                comment: '{"pluralForm":"one","pluralFormOther":"huzzah"}'
+            }),
+            new TranslationUnit({
+                source: "few",
+                sourceLocale: "en-US",
+                key: "huzzah",
+                file: "foo/bar/j.java",
+                project: "webapp",
+                targetLocale: "de-DE",
+                datatype: "x-android-resource",
+                quantity: "few",
+                resType: "plural",
+                comment: '{"pluralForm":"few","pluralFormOther":"huzzah"}'
+            })
+        ]);
 
-        x.addResource(res);
-
-        var actual = x.serialize();
-        var expected =
+        let actual = x.serialize();
+        let expected =
             '<?xml version="1.0" encoding="utf-8"?>\n' +
             '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
             '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
@@ -848,271 +608,10 @@ export const testXliff20 = {
         test.done();
     },
 
-    testXliff20SerializeWithSourceOnlyAndArray: function(test) {
-        test.expect(2);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        var res = new ContextResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            targetLocale: "de-DE"
-        });
-
-        x.addResource(res);
-
-        res = new ResourceArray({
-            sourceArray: ["one", "two", "three"],
-            sourceLocale: "en-US",
-            key: "huzzah",
-            pathName: "foo/bar/j.java",
-            project: "webapp",
-            targetLocale: "de-DE"
-        });
-
-        x.addResource(res);
-
-        var actual = x.serialize();
-        var expected =
-            '<?xml version="1.0" encoding="utf-8"?>\n' +
-            '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
-            '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-            '    <group id="group_1" name="plaintext">\n' +
-            '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
-            '        <segment>\n' +
-            '          <source>Asdf asdf</source>\n' +
-            '        </segment>\n' +
-            '      </unit>\n' +
-            '    </group>\n' +
-            '  </file>\n' +
-            '  <file original="foo/bar/j.java" l:project="webapp">\n' +
-            '    <group id="group_2" name="x-android-resource">\n' +
-            '      <unit id="2" name="huzzah" type="res:array" l:datatype="x-android-resource" l:index="0">\n' +
-            '        <segment>\n' +
-            '          <source>one</source>\n' +
-            '        </segment>\n' +
-            '      </unit>\n' +
-            '      <unit id="3" name="huzzah" type="res:array" l:datatype="x-android-resource" l:index="1">\n' +
-            '        <segment>\n' +
-            '          <source>two</source>\n' +
-            '        </segment>\n' +
-            '      </unit>\n' +
-            '      <unit id="4" name="huzzah" type="res:array" l:datatype="x-android-resource" l:index="2">\n' +
-            '        <segment>\n' +
-            '          <source>three</source>\n' +
-            '        </segment>\n' +
-            '      </unit>\n' +
-            '    </group>\n' +
-            '  </file>\n' +
-            '</xliff>';
-
-        diff(actual, expected);
-        test.equal(actual, expected);
-        test.done();
-    },
-
-    testXliff20SerializeWithExplicitIds: function(test) {
-        test.expect(2);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            target: "baby baby",
-            targetLocale: "nl-NL",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            origin: "target",
-            id: 4444444
-        });
-
-        x.addResource(res);
-
-        res = new ResourceString({
-            source: "abcdef",
-            sourceLocale: "en-US",
-            target: "hijklmn",
-            targetLocale: "nl-NL",
-            key: "asdf",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            origin: "target"
-        });
-
-        x.addResource(res);
-
-        var actual = x.serialize();
-        var expected =
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="nl-NL" xmlns:l="http://ilib-js.com/loctool">\n' +
-                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-                '    <group id="group_1" name="plaintext">\n' +
-                '      <unit id="4444444" name="foobar" type="res:string" l:datatype="plaintext">\n' +
-                '        <segment>\n' +
-                '          <source>Asdf asdf</source>\n' +
-                '          <target>baby baby</target>\n' +
-                '        </segment>\n' +
-                '      </unit>\n' +
-                '      <unit id="4444445" name="asdf" type="res:string" l:datatype="plaintext">\n' +
-                '        <segment>\n' +
-                '          <source>abcdef</source>\n' +
-                '          <target>hijklmn</target>\n' +
-                '        </segment>\n' +
-                '      </unit>\n' +
-                '    </group>\n' +
-                '  </file>\n' +
-                '</xliff>';
-        diff(actual, expected);
-        test.equal(actual, expected);
-
-        test.done();
-    },
-
-    testXliff20SerializeWithSourceAndTarget: function(test) {
-        test.expect(2);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        var res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            target: "foobarfoo",
-            targetLocale: "de-DE",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp",
-            origin: "target"
-        });
-
-        x.addResource(res);
-
-        res = new ResourceString({
-            source: "baby baby",
-            sourceLocale: "en-US",
-            target: "bebe bebe",
-            targetLocale: "de-DE",
-            key: "huzzah",
-            pathName: "foo/bar/j.java",
-            project: "webapp",
-            origin: "target"
-        });
-
-        x.addResource(res);
-
-        var expected =
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
-                '  <file original="foo/bar/asdf.java" l:project="webapp">\n' +
-                '    <group id="group_1" name="plaintext">\n' +
-                '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
-                '        <segment>\n' +
-                '          <source>Asdf asdf</source>\n' +
-                '          <target>foobarfoo</target>\n' +
-                '        </segment>\n' +
-                '      </unit>\n' +
-                '    </group>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
-                '    <group id="group_2" name="plaintext">\n' +
-                '      <unit id="2" name="huzzah" type="res:string" l:datatype="plaintext">\n' +
-                '        <segment>\n' +
-                '          <source>baby baby</source>\n' +
-                '          <target>bebe bebe</target>\n' +
-                '        </segment>\n' +
-                '      </unit>\n' +
-                '    </group>\n' +
-                '  </file>\n' +
-                '</xliff>';
-
-        diff(x.serialize(), expected);
-        test.equal(x.serialize(), expected);
-
-        test.done();
-    },
-
-    testXliff20SerializeWithSourceAndTargetAndComment: function(test) {
-        test.expect(2);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        var res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            target: "foobarfoo",
-            targetLocale: "de-DE",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp",
-            comment: "foobar is where it's at!"
-        });
-
-        x.addResource(res);
-
-        res = new ResourceString({
-            source: "baby baby",
-            sourceLocale: "en-US",
-            target: "bebe bebe",
-            targetLocale: "de-DE",
-            key: "huzzah",
-            pathName: "foo/bar/j.java",
-            project: "webapp",
-            comment: "come & enjoy it with us"
-        });
-
-        x.addResource(res);
-
-        var expected =
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
-                '  <file original="foo/bar/asdf.java" l:project="webapp">\n' +
-                '    <group id="group_1" name="plaintext">\n' +
-                '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
-                '        <notes>\n' +
-                '          <note appliesTo="source">foobar is where it\'s at!</note>\n' +
-                '        </notes>\n' +
-                '        <segment>\n' +
-                '          <source>Asdf asdf</source>\n' +
-                '          <target>foobarfoo</target>\n' +
-                '        </segment>\n' +
-                '      </unit>\n' +
-                '    </group>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
-                '    <group id="group_2" name="plaintext">\n' +
-                '      <unit id="2" name="huzzah" type="res:string" l:datatype="plaintext">\n' +
-                '        <notes>\n' +
-                '          <note appliesTo="source">come &amp; enjoy it with us</note>\n' +
-                '        </notes>\n' +
-                '        <segment>\n' +
-                '          <source>baby baby</source>\n' +
-                '          <target>bebe bebe</target>\n' +
-                '        </segment>\n' +
-                '      </unit>\n' +
-                '    </group>\n' +
-                '  </file>\n' +
-                '</xliff>';
-
-        var actual = x.serialize();
-
-        diff(actual, expected);
-        test.equal(actual, expected);
-
-        test.done();
-    },
-
     testXliff20SerializeWithHeader: function(test) {
         test.expect(2);
 
-        var x = new Xliff({
+        const x = new Xliff({
             version: "2.0",
             "tool-id": "loctool",
             "tool-name": "Localization Tool",
@@ -1123,21 +622,22 @@ export const testXliff20 = {
         });
         test.ok(x);
 
-        res = new ResourceString({
+        const tu = new TranslationUnit({
             source: "Asdf asdf",
             sourceLocale: "en-US",
             target: "baby baby",
             targetLocale: "nl-NL",
             key: "foobar",
-            pathName: "foo/bar/asdf.java",
+            file: "foo/bar/asdf.java",
+            datatype: "plaintext",
             project: "webapp",
             origin: "target"
         });
 
-        x.addResource(res);
+        x.addTranslationUnit(tu);
 
-        var actual = x.serialize();
-        var expected =
+        let actual = x.serialize();
+        let expected =
                 '<?xml version="1.0" encoding="utf-8"?>\n' +
                 '<xliff version="2.0" srcLang="en-US" trgLang="nl-NL" xmlns:l="http://ilib-js.com/loctool">\n' +
                 '  <file original="foo/bar/asdf.java" l:project="webapp">\n' +
@@ -1160,225 +660,39 @@ export const testXliff20 = {
         test.done();
     },
 
-    testXliff20SerializeWithPlurals: function(test) {
-        test.expect(2);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        res = new ResourcePlural({
-            sourceStrings: {
-                "one": "There is 1 object.",
-                "other": "There are {n} objects."
-            },
-            sourceLocale: "en-US",
-            targetStrings: {
-                "one": "Da gibts 1 Objekt.",
-                "other": "Da gibts {n} Objekten."
-            },
-            targetLocale: "de-DE",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            resType: "plural",
-            origin: "target",
-            autoKey: true,
-            state: "new",
-            datatype: "ruby"
-        });
-
-        x.addResource(res);
-
-        var actual = x.serialize();
-        var expected =
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
-                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-                '    <group id="group_1" name="ruby">\n' +
-                '      <unit id="1" name="foobar" type="res:plural" l:datatype="ruby" l:category="one">\n' +
-                '        <notes>\n' +
-                '          <note appliesTo="source">{"pluralForm":"one","pluralFormOther":"foobar"}</note>\n' +
-                '        </notes>\n' +
-                '        <segment>\n' +
-                '          <source>There is 1 object.</source>\n' +
-                '          <target state="new">Da gibts 1 Objekt.</target>\n' +
-                '        </segment>\n' +
-                '      </unit>\n' +
-                '      <unit id="2" name="foobar" type="res:plural" l:datatype="ruby" l:category="other">\n' +
-                '        <notes>\n' +
-                '          <note appliesTo="source">{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
-                '        </notes>\n' +
-                '        <segment>\n' +
-                '          <source>There are {n} objects.</source>\n' +
-                '          <target state="new">Da gibts {n} Objekten.</target>\n' +
-                '        </segment>\n' +
-                '      </unit>\n' +
-                '    </group>\n' +
-                '  </file>\n' +
-                '</xliff>';
-        diff(actual, expected);
-        test.equal(actual, expected);
-
-        test.done();
-    },
-
-    testXliff20SerializeWithPluralsToLangWithMorePluralsThanEnglish: function(test) {
-        test.expect(2);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        res = new ResourcePlural({
-            sourceStrings: {
-                "one": "There is 1 object.",
-                "other": "There are {n} objects."
-            },
-            sourceLocale: "en-US",
-            targetStrings: {
-                "one": "Имеется {n} объект.",
-                "few": "Есть {n} объекта.",
-                "other": "Всего {n} объектов."
-            },
-            targetLocale: "ru-RU",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            resType: "plural",
-            origin: "target",
-            autoKey: true,
-            state: "new",
-            datatype: "ruby"
-        });
-
-        x.addResource(res);
-
-        var actual = x.serialize();
-        var expected =
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="ru-RU" xmlns:l="http://ilib-js.com/loctool">\n' +
-                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-                '    <group id="group_1" name="ruby">\n' +
-                '      <unit id="1" name="foobar" type="res:plural" l:datatype="ruby" l:category="one">\n' +
-                '        <notes>\n' +
-                '          <note appliesTo="source">{"pluralForm":"one","pluralFormOther":"foobar"}</note>\n' +
-                '        </notes>\n' +
-                '        <segment>\n' +
-                '          <source>There is 1 object.</source>\n' +
-                '          <target state="new">Имеется {n} объект.</target>\n' +
-                '        </segment>\n' +
-                '      </unit>\n' +
-                '      <unit id="2" name="foobar" type="res:plural" l:datatype="ruby" l:category="few">\n' +
-                '        <notes>\n' +
-                '          <note appliesTo="source">{"pluralForm":"few","pluralFormOther":"foobar"}</note>\n' +
-                '        </notes>\n' +
-                '        <segment>\n' +
-                '          <source>There are {n} objects.</source>\n' +
-                '          <target state="new">Есть {n} объекта.</target>\n' +
-                '        </segment>\n' +
-                '      </unit>\n' +
-                '      <unit id="3" name="foobar" type="res:plural" l:datatype="ruby" l:category="other">\n' +
-                '        <notes>\n' +
-                '          <note appliesTo="source">{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
-                '        </notes>\n' +
-                '        <segment>\n' +
-                '          <source>There are {n} objects.</source>\n' +
-                '          <target state="new">Всего {n} объектов.</target>\n' +
-                '        </segment>\n' +
-                '      </unit>\n' +
-                '    </group>\n' +
-                '  </file>\n' +
-                '</xliff>';
-        diff(actual, expected);
-        test.equal(actual, expected);
-
-        test.done();
-    },
-
-    testXliff20SerializeWithArrays: function(test) {
-        test.expect(2);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        res = new ResourceArray({
-            sourceArray: ["Zero", "One", "Two"],
-            sourceLocale: "en-US",
-            targetArray: ["Zero", "Eins", "Zwei"],
-            targetLocale: "de-DE",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            origin: "target"
-        });
-
-        x.addResource(res);
-
-        var actual = x.serialize();
-        var expected =
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
-                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-                '    <group id="group_1" name="x-android-resource">\n' +
-                '      <unit id="1" name="foobar" type="res:array" l:datatype="x-android-resource" l:index="0">\n' +
-                '        <segment>\n' +
-                '          <source>Zero</source>\n' +
-                '          <target>Zero</target>\n' +
-                '        </segment>\n' +
-                '      </unit>\n' +
-                '      <unit id="2" name="foobar" type="res:array" l:datatype="x-android-resource" l:index="1">\n' +
-                '        <segment>\n' +
-                '          <source>One</source>\n' +
-                '          <target>Eins</target>\n' +
-                '        </segment>\n' +
-                '      </unit>\n' +
-                '      <unit id="3" name="foobar" type="res:array" l:datatype="x-android-resource" l:index="2">\n' +
-                '        <segment>\n' +
-                '          <source>Two</source>\n' +
-                '          <target>Zwei</target>\n' +
-                '        </segment>\n' +
-                '      </unit>\n' +
-                '    </group>\n' +
-                '  </file>\n' +
-                '</xliff>';
-        diff(actual, expected)
-        test.equal(actual, expected);
-        test.done();
-    },
-
     testXliff20SerializeWithXMLEscaping: function(test) {
         test.expect(2);
 
-        var x = new Xliff({version: "2.0"});
+        const x = new Xliff({version: 2.0});
         test.ok(x);
 
-        var res = new ResourceString({
-            source: "Asdf <b>asdf</b>",
-            sourceLocale: "en-US",
-            target: "Asdf 'quotes'",
-            targetLocale: "de-DE",
-            key: 'foobar "asdf"',
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            origin: "target"
-        });
+        x.addTranslationUnits([
+            new TranslationUnit({
+                source: "Asdf <b>asdf</b>",
+                sourceLocale: "en-US",
+                target: "Asdf 'quotes'",
+                targetLocale: "de-DE",
+                key: 'foobar "asdf"',
+                file: "foo/bar/asdf.java",
+                project: "androidapp",
+                origin: "target",
+                datatype: "plaintext"
+            }),
+            new TranslationUnit({
+                source: "baby &lt;b&gt;baby&lt;/b&gt;",
+                sourceLocale: "en-US",
+                target: "baby #(test)",
+                targetLocale: "de-DE",
+                key: "huzzah &quot;asdf&quot; #(test)",
+                file: "foo/bar/j.java",
+                project: "webapp",
+                origin: "target",
+                datatype: "plaintext"
+            })
+        ]);
 
-        x.addResource(res);
-
-        res = new ResourceString({
-            source: "baby &lt;b&gt;baby&lt;/b&gt;",
-            sourceLocale: "en-US",
-            target: "baby #(test)",
-            targetLocale: "de-DE",
-            key: "huzzah &quot;asdf&quot; #(test)",
-            pathName: "foo/bar/j.java",
-            project: "webapp",
-            origin: "target"
-        });
-
-        x.addResource(res);
-
-        var actual = x.serialize();
-        var expected =
+        let actual = x.serialize();
+        let expected =
                 '<?xml version="1.0" encoding="utf-8"?>\n' +
                 '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
                 '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
@@ -1408,24 +722,87 @@ export const testXliff20 = {
         test.done();
     },
 
+    testXliff20SerializeWithXMLEscapingInResname: function(test) {
+        test.expect(2);
+
+        const x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        x.addTranslationUnits([
+            new TranslationUnit({
+                source: "Asdf <b>asdf</b>",
+                sourceLocale: "en-US",
+                target: "Asdf 'quotes'",
+                targetLocale: "de-DE",
+                key: 'foobar <i>asdf</i>',
+                file: "foo/bar/asdf.java",
+                project: "androidapp",
+                origin: "target",
+                datatype: "plaintext"
+            }),
+            new TranslationUnit({
+                source: "baby &lt;b&gt;baby&lt;/b&gt;",
+                sourceLocale: "en-US",
+                target: "baby #(test)",
+                targetLocale: "de-DE",
+                key: "huzzah <b>asdf</b> #(test)",
+                file: "foo/bar/j.java",
+                project: "webapp",
+                origin: "target",
+                datatype: "plaintext"
+            })
+        ]);
+
+        let actual = x.serialize();
+        let expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <group id="group_1" name="plaintext">\n' +
+                '      <unit id="1" name="foobar &lt;i>asdf&lt;/i>" type="res:string" l:datatype="plaintext">\n' +
+                '        <segment>\n' +
+                '          <source>Asdf &lt;b&gt;asdf&lt;/b&gt;</source>\n' +
+                '          <target>Asdf \'quotes\'</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <group id="group_2" name="plaintext">\n' +
+                '      <unit id="2" name="huzzah &lt;b>asdf&lt;/b> #(test)" type="res:string" l:datatype="plaintext">\n' +
+                '        <segment>\n' +
+                '          <source>baby &amp;lt;b&amp;gt;baby&amp;lt;/b&amp;gt;</source>\n' +   // double escaped!
+                '          <target>baby #(test)</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
     testXliff20SerializeWithXMLEscapingWithQuotes: function(test) {
         test.expect(2);
 
-        var x = new Xliff({version: "2.0"});
+        const x = new Xliff({version: 2.0});
         test.ok(x);
 
-        var res = new ResourceString({
+        const tu = new TranslationUnit({
             source: "Here are \"double\" and 'single' quotes.",
             sourceLocale: "en-US",
             target: "Hier zijn \"dubbel\" en 'singel' quotaties.",
             targetLocale: "nl-NL",
             key: '"double" and \'single\'',
-            pathName: "foo/bar/asdf.java",
+            file: "foo/bar/asdf.java",
             project: "androidapp",
-            origin: "target"
+            origin: "target",
+            datatype: "plaintext"
         });
 
-        x.addResource(res);
+        x.addTranslationUnit(tu);
 
         test.equal(x.serialize(),
                 '<?xml version="1.0" encoding="utf-8"?>\n' +
@@ -1448,1621 +825,62 @@ export const testXliff20 = {
     testXliff20SerializeWithEscapeCharsInResname: function(test) {
         test.expect(2);
 
-        var x = new Xliff({version: "2.0"});
+        const x = new Xliff({version: 2.0});
         test.ok(x);
 
-        var res = new ResourceString({
-            source: "Here are \\ndouble\\n quotes.",
-            sourceLocale: "en-US",
-            target: "Hier zijn \\ndubbel\\n quotaties.",
-            targetLocale: "nl-NL",
-            key: 'Double \\ndouble\\n.',
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            origin: "target"
-        });
+        x.addTranslationUnits([
+            new TranslationUnit({
+                source: "Asdf asdf",
+                sourceLocale: "en-US",
+                target: "Asdf translated",
+                targetLocale: "de-DE",
+                key: 'asdf \\n\\nasdf',
+                file: "foo/bar/asdf.java",
+                project: "androidapp",
+                origin: "target",
+                datatype: "plaintext"
+            }),
+            new TranslationUnit({
+                source: "asdf \\t\\n\\n",
+                sourceLocale: "en-US",
+                target: "fdsa \\t\\n\\n fdsa\\n",
+                targetLocale: "de-DE",
+                key: "asdf \\t\\n\\n asdf\\n",
+                file: "foo/bar/j.java",
+                project: "webapp",
+                origin: "target",
+                datatype: "plaintext"
+            })
+        ]);
 
-        x.addResource(res);
-
-        test.equal(x.serialize(),
+        let actual = x.serialize();
+        let expected =
                 '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="nl-NL" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
                 '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
                 '    <group id="group_1" name="plaintext">\n' +
-                '      <unit id="1" name="Double \\ndouble\\n." type="res:string" l:datatype="plaintext">\n' +
-                '        <segment>\n' +
-                '          <source>Here are \\ndouble\\n quotes.</source>\n' +
-                '          <target>Hier zijn \\ndubbel\\n quotaties.</target>\n' +
-                '        </segment>\n' +
-                '      </unit>\n' +
-                '    </group>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        test.done();
-    },
-
-    testXliff20SerializeWithComments: function(test) {
-        test.expect(2);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            target: "baby baby",
-            targetLocale: "nl-NL",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "androidapp",
-            comment: "A very nice string",
-            origin: "target"
-        });
-
-        x.addResource(res);
-
-        test.equal(x.serialize(),
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="nl-NL" xmlns:l="http://ilib-js.com/loctool">\n' +
-                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-                '    <group id="group_1" name="plaintext">\n' +
-                '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
-                '        <notes>\n' +
-                '          <note appliesTo="source">A very nice string</note>\n' +
-                '        </notes>\n' +
+                '      <unit id="1" name="asdf \\n\\nasdf" type="res:string" l:datatype="plaintext">\n' +
                 '        <segment>\n' +
                 '          <source>Asdf asdf</source>\n' +
-                '          <target>baby baby</target>\n' +
+                '          <target>Asdf translated</target>\n' +
                 '        </segment>\n' +
                 '      </unit>\n' +
                 '    </group>\n' +
                 '  </file>\n' +
-                '</xliff>');
-
-        test.done();
-    },
-
-    testXliff20DeserializeWithSourceOnly: function(test) {
-        test.expect(21);
-
-        var x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" \n' +
-                '  xmlns:l="http://ilib-js.com/loctool">\n' +
-                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-                '    <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
-                '      <segment>\n' +
-                '        <source>Asdf asdf</source>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
                 '  <file original="foo/bar/j.java" l:project="webapp">\n' +
-                '    <unit id="2" name="huzzah" type="res:string" l:datatype="plaintext">\n' +
-                '      <segment>\n' +
-                '        <source>baby baby</source>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        var reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 2);
-
-        test.equal(reslist[0].getSource(), "Asdf asdf");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.ok(!reslist[0].getTarget());
-        test.equal(reslist[0].getTargetLocale(), "de-DE");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), "1");
-
-        test.equal(reslist[1].getSource(), "baby baby");
-        test.equal(reslist[1].getSourceLocale(), "en-US");
-        test.ok(!reslist[1].getTarget());
-        test.equal(reslist[1].getTargetLocale(), "de-DE");
-        test.equal(reslist[1].getKey(), "huzzah");
-        test.equal(reslist[1].getPath(), "foo/bar/j.java");
-        test.equal(reslist[1].getProject(), "webapp");
-        test.equal(reslist[1].resType, "string");
-        test.equal(reslist[1].getId(), "2");
-
-        test.done();
-    },
-
-    testXliff20DeserializeWithSourceAndTarget: function(test) {
-        test.expect(21);
-
-        var x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
-                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-                '    <unit id="1" name="foobar" type="res:string">\n' +
-                '      <segment>\n' +
-                '        <source>Asdf asdf</source>\n' +
-                '        <target>foobarfoo</target>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
-                '    <unit id="2" name="huzzah" type="res:string">\n' +
-                '      <segment>\n' +
-                '        <source>baby baby</source>\n' +
-                '        <target>bebe bebe</target>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        // console.log("x is " + JSON.stringify(x, undefined, 4));
-        var reslist = x.getResources();
-        // console.log("x is now " + JSON.stringify(x, undefined, 4));
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 2);
-
-        test.equal(reslist[0].getSource(), "Asdf asdf");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), "1");
-        test.equal(reslist[0].getTarget(), "foobarfoo");
-        test.equal(reslist[0].getTargetLocale(), "de-DE");
-
-        test.equal(reslist[1].getSource(), "baby baby");
-        test.equal(reslist[1].getSourceLocale(), "en-US");
-        test.equal(reslist[1].getKey(), "huzzah");
-        test.equal(reslist[1].getPath(), "foo/bar/j.java");
-        test.equal(reslist[1].getProject(), "webapp");
-        test.equal(reslist[1].resType, "string");
-        test.equal(reslist[1].getId(), "2");
-        test.equal(reslist[1].getTarget(), "bebe bebe");
-        test.equal(reslist[1].getTargetLocale(), "de-DE");
-
-        test.done();
-    },
-
-    testXliff20DeserializeWithXMLUnescaping: function(test) {
-        test.expect(19);
-
-        var x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" xmlns:l="http://ilib-js.com/loctool" srcLang="en-US">\n' +
-                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-                '    <unit id="1" name="foobar" type="res:string">\n' +
-                '      <segment>\n' +
-                '        <source>Asdf &lt;b&gt;asdf&lt;/b&gt;</source>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
-                '    <unit id="2" name="huzzah" type="res:string">\n' +
-                '      <segment>\n' +
-                '        <source>baby &amp;lt;b&amp;gt;baby&amp;lt;/b&amp;gt;</source>\n' +   // double escaped!
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        var reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 2);
-
-        test.equal(reslist[0].getSource(), "Asdf <b>asdf</b>");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), "1");
-        test.ok(!reslist[0].getTarget());
-
-        test.equal(reslist[1].getSource(), "baby &lt;b&gt;baby&lt;/b&gt;");
-        test.equal(reslist[1].getSourceLocale(), "en-US");
-        test.equal(reslist[1].getKey(), "huzzah");
-        test.equal(reslist[1].getPath(), "foo/bar/j.java");
-        test.equal(reslist[1].getProject(), "webapp");
-        test.equal(reslist[1].resType, "string");
-        test.equal(reslist[1].getId(), "2");
-        test.ok(!reslist[1].getTarget());
-
-        test.done();
-    },
-
-    testXliff20DeserializeWithEscapedNewLines: function(test) {
-        test.expect(17);
-
-        var x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="en-CA" \n' +
-                '  xmlns:l="http://ilib-js.com/loctool">\n' +
-                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-                '    <unit id="1" name="foobar" type="res:string">\n' +
-                '      <segment>\n' +
-                '        <source>a\\nb</source>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
-                '    <unit id="2" name="huzzah" type="res:string">\n' +
-                '      <segment>\n' +
-                '        <source>e\\nh</source>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        var reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 2);
-
-        test.equal(reslist[0].getSource(), "a\\nb");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), "1");
-
-        test.equal(reslist[1].getSource(), "e\\nh");
-        test.equal(reslist[1].getSourceLocale(), "en-US");
-        test.equal(reslist[1].getKey(), "huzzah");
-        test.equal(reslist[1].getPath(), "foo/bar/j.java");
-        test.equal(reslist[1].getProject(), "webapp");
-        test.equal(reslist[1].resType, "string");
-        test.equal(reslist[1].getId(), "2");
-
-        test.done();
-    },
-
-    testXliff20DeserializeWithEscapedNewLinesInResname: function(test) {
-        test.expect(17);
-
-        var x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="en-CA" \n' +
-                '  xmlns:l="http://ilib-js.com/loctool">\n' +
-                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-                '    <unit id="1" name="foobar\\nbar\\t" type="res:string">\n' +
-                '      <segment>\n' +
-                '        <source>a\\nb</source>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
-                '    <unit id="2" name="huzzah\\n\\na plague on both your houses" type="res:string">\n' +
-                '      <segment>\n' +
-                '        <source>e\\nh</source>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        var reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 2);
-
-        test.equal(reslist[0].getSource(), "a\\nb");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar\\nbar\\t");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), "1");
-
-        test.equal(reslist[1].getSource(), "e\\nh");
-        test.equal(reslist[1].getSourceLocale(), "en-US");
-        test.equal(reslist[1].getKey(), "huzzah\\n\\na plague on both your houses");
-        test.equal(reslist[1].getPath(), "foo/bar/j.java");
-        test.equal(reslist[1].getProject(), "webapp");
-        test.equal(reslist[1].resType, "string");
-        test.equal(reslist[1].getId(), "2");
-
-        test.done();
-    },
-
-    testXliff20DeserializeWithPlurals: function(test) {
-        test.expect(10);
-
-        var x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" xmlns:l="http://ilib-js.com/loctool" srcLang="en-US">\n' +
-                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-                '    <unit id="1" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="one">\n' +
-                '      <segment>\n' +
-                '        <source>There is 1 object.</source>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '    <unit id="2" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="other">\n' +
-                '      <segment>\n' +
-                '        <source>There are {n} objects.</source>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        // console.log("x is " + JSON.stringify(x, undefined, 4));
-
-        var reslist = x.getResources();
-
-        // console.log("after get resources x is " + JSON.stringify(x, undefined, 4));
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.deepEqual(reslist[0].getSourcePlurals(), {
-            one: "There is 1 object.",
-            other: "There are {n} objects."
-        });
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "plural");
-        test.equal(reslist[0].getId(), "1");
-
-        test.done();
-    },
-
-    testXliff20DeserializeWithPluralsTranslated: function(test) {
-        test.expect(13);
-
-        var x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="es-US" xmlns:l="http://ilib-js.com/loctool">\n' +
-                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-                '    <unit id="1" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="one">\n' +
-                '      <segment>\n' +
-                '        <source>There is 1 object.</source>\n' +
-                '        <target>Hay 1 objeto.</target>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '    <unit id="2" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="other">\n' +
-                '      <segment>\n' +
-                '        <source>There are {n} objects.</source>\n' +
-                '        <target>Hay {n} objetos.</target>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        // console.log("x is " + JSON.stringify(x, undefined, 4));
-
-        var reslist = x.getResources();
-
-        // console.log("after get resources x is " + JSON.stringify(x, undefined, 4));
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.deepEqual(reslist[0].getSourcePlurals(), {
-            one: "There is 1 object.",
-            other: "There are {n} objects."
-        });
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "plural");
-        test.equal(reslist[0].getId(), "1");
-        test.equal(reslist[0].getOrigin(), "source");
-
-        test.deepEqual(reslist[0].getTargetPlurals(), {
-            one: "Hay 1 objeto.",
-            other: "Hay {n} objetos."
-        });
-        test.equal(reslist[0].getTargetLocale(), "es-US");
-
-        test.done();
-    },
-
-    testXliff20DeserializeWithArrays: function(test) {
-        test.expect(10);
-
-        var x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
-                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-                '    <unit id="1" name="foobar" type="res:array" l:datatype="x-android-resource" l:index="0">\n' +
-                '      <segment>\n' +
-                '        <source>Zero</source>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '    <unit id="2" name="foobar" type="res:array" l:datatype="x-android-resource" l:index="1">\n' +
-                '      <segment>\n' +
-                '        <source>One</source>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '    <unit id="3" name="foobar" type="res:array" l:datatype="x-android-resource" l:index="2">\n' +
-                '      <segment>\n' +
-                '        <source>Two</source>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        var reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.deepEqual(reslist[0].getSourceArray(), ["Zero", "One", "Two"]);
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "array");
-        test.ok(!reslist[0].getTargetArray());
-
-        test.done();
-    },
-
-    testXliff20DeserializeWithArraysTranslated: function(test) {
-        test.expect(12);
-
-        var x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
-                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-                '    <unit id="1" name="foobar" type="res:array" l:datatype="x-android-resource" l:index="0">\n' +
-                '      <segment>\n' +
-                '        <source>Zero</source>\n' +
-                '        <target>Zero</target>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '    <unit id="2" name="foobar" type="res:array" l:datatype="x-android-resource" l:index="1">\n' +
-                '      <segment>\n' +
-                '        <source>One</source>\n' +
-                '        <target>Eins</target>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '    <unit id="3" name="foobar" type="res:array" l:datatype="x-android-resource" l:index="2">\n' +
-                '      <segment>\n' +
-                '        <source>Two</source>\n' +
-                '        <target>Zwei</target>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        var reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.deepEqual(reslist[0].getSourceArray(), ["Zero", "One", "Two"]);
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "array");
-        test.equal(reslist[0].getOrigin(), "source");
-        test.deepEqual(reslist[0].getTargetArray(), ["Zero", "Eins", "Zwei"]);
-        test.equal(reslist[0].getTargetLocale(), "de-DE");
-
-        test.done();
-    },
-
-    testXliff20DeserializeWithArraysAndTranslations: function(test) {
-        test.expect(20);
-
-        var x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="es-US" xmlns:l="http://ilib-js.com/loctool">\n' +
-                '  <file original="res/values/arrays.xml" l:project="androidapp">\n' +
-                '    <unit id="2" name="huzzah" type="res:array" l:datatype="x-android-resource" l:index="0">\n' +
-                '      <segment>\n' +
-                '        <source>This is element 0</source>\n' +
-                '        <target>Este es 0</target>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '    <unit id="3" name="huzzah" type="res:array" l:datatype="x-android-resource" l:index="1">\n' +
-                '      <segment>\n' +
-                '        <source>This is element 1</source>\n' +
-                '        <target>Este es 1</target>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '    <unit id="4" name="huzzah" type="res:array" l:datatype="x-android-resource" l:index="2">\n' +
-                '      <segment>\n' +
-                '        <source>This is element 2</source>\n' +
-                '        <target>Este es 2</target>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '    <unit id="5" name="huzzah" type="res:array" l:datatype="x-android-resource" l:index="3">\n' +
-                '      <segment>\n' +
-                '        <source>This is element 3</source>\n' +
-                '        <target>Este es 3</target>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        var reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getTargetLocale(), "es-US");
-        test.equal(reslist[0].getKey(), "huzzah");
-        test.equal(reslist[0].getPath(), "res/values/arrays.xml");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "array");
-        test.equal(reslist[0].getOrigin(), "source");
-
-        var items = reslist[0].getSourceArray();
-
-        test.equal(items.length, 4);
-        test.equal(items[0], "This is element 0");
-        test.equal(items[1], "This is element 1");
-        test.equal(items[2], "This is element 2");
-        test.equal(items[3], "This is element 3");
-
-        items = reslist[0].getTargetArray();
-
-        test.equal(items.length, 4);
-        test.equal(items[0], "Este es 0");
-        test.equal(items[1], "Este es 1");
-        test.equal(items[2], "Este es 2");
-        test.equal(items[3], "Este es 3");
-
-        test.done();
-    },
-
-    testXliff20DeserializeWithArraysAndTranslationsPartial: function(test) {
-        test.expect(20);
-
-        var x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="es-US" xmlns:l="http://ilib-js.com/loctool">\n' +
-                '  <file original="res/values/arrays.xml" l:project="androidapp">\n' +
-                '    <unit id="5" name="huzzah" type="res:array" l:datatype="x-android-resource" l:index="3">\n' +
-                '      <segment>\n' +
-                '        <source>This is element 3</source>\n' +
-                '        <target>Este es 3</target>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        var reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getTargetLocale(), "es-US");
-        test.equal(reslist[0].getKey(), "huzzah");
-        test.equal(reslist[0].getPath(), "res/values/arrays.xml");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "array");
-        test.equal(reslist[0].getOrigin(), "source");
-
-        var items = reslist[0].getSourceArray();
-
-        test.equal(items.length, 4);
-        test.equal(items[0], null);
-        test.equal(items[1], null);
-        test.equal(items[2], null);
-        test.equal(items[3], "This is element 3");
-
-        items = reslist[0].getTargetArray();
-
-        test.equal(items.length, 4);
-        test.equal(items[0], null);
-        test.equal(items[1], null);
-        test.equal(items[2], null);
-        test.equal(items[3], "Este es 3");
-
-        test.done();
-    },
-
-    testXliff20DeserializeWithComments: function(test) {
-        test.expect(18);
-
-        var x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" xmlns:l="http://ilib-js.com/loctool" srcLang="en-US">\n' +
-                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-                '    <unit id="1" name="foobar" type="res:string">\n' +
-                '      <notes>\n' +
-                '        <note appliesTo="source">A very nice string</note>\n' +
-                '      </notes>\n' +
-                '      <segment>\n' +
-                '        <source>Asdf asdf</source>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
-                '    <unit id="2" name="huzzah" type="res:string">\n' +
-                '      <notes>\n' +
-                '        <note appliesTo="source">Totally awesome.</note>\n' +
-                '      </notes>\n' +
-                '      <segment>\n' +
-                '        <source>baby baby</source>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        var reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist[0].getSource(), "Asdf asdf");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getComment(), "A very nice string");
-        test.equal(reslist[0].getId(), "1");
-
-        test.equal(reslist[1].getSource(), "baby baby");
-        test.equal(reslist[1].getSourceLocale(), "en-US");
-        test.equal(reslist[1].getKey(), "huzzah");
-        test.equal(reslist[1].getPath(), "foo/bar/j.java");
-        test.equal(reslist[1].getProject(), "webapp");
-        test.equal(reslist[1].resType, "string");
-        test.equal(reslist[1].getComment(), "Totally awesome.");
-        test.equal(reslist[1].getId(), "2");
-
-        test.done();
-    },
-
-    testXliff20DeserializeWithContext: function(test) {
-        test.expect(19);
-
-        var x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
-                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-                '    <unit id="1" name="foobar" type="res:string" l:context="na na na">\n' +
-                '      <segment>\n' +
-                '        <source>Asdf asdf</source>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
-                '    <unit id="2" name="huzzah" type="res:string" l:context="asdf">\n' +
-                '      <segment>\n' +
-                '        <source>baby baby</source>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        var reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 2);
-
-        test.equal(reslist[0].getSource(), "Asdf asdf");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), "1");
-        test.equal(reslist[0].getContext(), "na na na");
-
-        test.equal(reslist[1].getSource(), "baby baby");
-        test.equal(reslist[1].getSourceLocale(), "en-US");
-        test.equal(reslist[1].getKey(), "huzzah");
-        test.equal(reslist[1].getPath(), "foo/bar/j.java");
-        test.equal(reslist[1].getProject(), "webapp");
-        test.equal(reslist[1].resType, "string");
-        test.equal(reslist[1].getId(), "2");
-        test.equal(reslist[1].getContext(), "asdf");
-
-        test.done();
-    },
-
-    testXliff20DeserializeRealFile: function(test) {
-        test.expect(3);
-
-        var x = new Xliff();
-        test.ok(x);
-
-        var fs = require("fs");
-
-        var str = fs.readFileSync("testfiles/test4.xliff", "utf-8");
-
-        x.deserialize(str);
-
-        var reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 4);
-
-        test.done();
-    },
-
-    testXliff20DeserializeEmptySource: function(test) {
-        test.expect(12);
-
-        var x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
-                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-                '    <unit id="1" name="foobar" type="res:string" l:context="na na na">\n' +
-                '      <segment>\n' +
-                '        <source></source>\n' +
-                '        <target>Baby Baby</target>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
-                '    <unit id="2" name="huzzah" type="res:string">\n' +
-                '      <segment>\n' +
-                '        <source>baby baby</source>\n' +
-                '        <target>bebe bebe</target>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        var reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.equal(reslist[0].getSource(), "baby baby");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "huzzah");
-        test.equal(reslist[0].getPath(), "foo/bar/j.java");
-        test.equal(reslist[0].getProject(), "webapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), "2");
-
-        test.equal(reslist[0].getTarget(), "bebe bebe");
-        test.equal(reslist[0].getTargetLocale(), "de-DE");
-
-        test.done();
-    },
-
-    testXliff20DeserializeEmptyTarget: function(test) {
-        test.expect(23);
-
-        var x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">\n' +
-                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-                '    <unit id="1" name="foobar" type="res:string">\n' +
-                '      <segment>\n' +
-                '        <source>Asdf asdf</source>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
-                '    <unit id="2" name="huzzah" type="res:string">\n' +
-                '      <segment>\n' +
-                '        <source>baby baby</source>\n' +
-                '        <target></target>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        var reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 2);
-
-        test.equal(reslist[0].getSource(), "Asdf asdf");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.ok(!reslist[0].getTarget());
-        test.equal(reslist[0].getTargetLocale(), "fr-FR");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), "1");
-        test.equal(reslist[0].getOrigin(), "source");
-
-        test.equal(reslist[1].getSource(), "baby baby");
-        test.equal(reslist[1].getSourceLocale(), "en-US");
-        test.ok(!reslist[0].getTarget());
-        test.equal(reslist[0].getTargetLocale(), "fr-FR");
-        test.equal(reslist[1].getKey(), "huzzah");
-        test.equal(reslist[1].getPath(), "foo/bar/j.java");
-        test.equal(reslist[1].getProject(), "webapp");
-        test.equal(reslist[1].resType, "string");
-        test.equal(reslist[1].getId(), "2");
-        test.equal(reslist[1].getOrigin(), "source");
-
-        test.done();
-    },
-
-    testXliff20DeserializeEmptyTargetNoTargetLocale: function(test) {
-        test.expect(23);
-
-        var x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" xmlns:l="http://ilib-js.com/loctool" srcLang="en-US">\n' +
-                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
-                '    <unit id="1" name="foobar" type="res:string">\n' +
-                '      <segment>\n' +
-                '        <source>Asdf asdf</source>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
-                '    <unit id="2" name="huzzah" type="res:string">\n' +
-                '      <segment>\n' +
-                '        <source>baby baby</source>\n' +
-                '        <target></target>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        var reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 2);
-
-        test.equal(reslist[0].getSource(), "Asdf asdf");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.ok(!reslist[0].getTarget());
-        test.ok(!reslist[0].getTargetLocale());
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "androidapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), "1");
-        test.equal(reslist[0].getOrigin(), "source");
-
-        test.equal(reslist[1].getSource(), "baby baby");
-        test.equal(reslist[1].getSourceLocale(), "en-US");
-        test.ok(!reslist[0].getTarget());
-        test.ok(!reslist[0].getTargetLocale());
-        test.equal(reslist[1].getKey(), "huzzah");
-        test.equal(reslist[1].getPath(), "foo/bar/j.java");
-        test.equal(reslist[1].getProject(), "webapp");
-        test.equal(reslist[1].resType, "string");
-        test.equal(reslist[1].getId(), "2");
-        test.equal(reslist[1].getOrigin(), "source");
-
-        test.done();
-    },
-
-    testXliff20DeserializeWithMultipleSegments: function(test) {
-        test.expect(12);
-
-        var x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">\n' +
-                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
-                '    <unit id="2" name="huzzah" type="res:string">\n' +
-                '      <segment id="1">\n' +
-                '        <source>seg1 </source>\n' +
-                '        <target>This is segment 1. </target>\n' +
-                '      </segment>\n' +
-                '      <segment id="2">\n' +
-                '        <source>seg2 </source>\n' +
-                '        <target>This is segment 2. </target>\n' +
-                '      </segment>\n' +
-                '      <segment id="3">\n' +
-                '        <source>seg3</source>\n' +
-                '        <target>This is segment 3.</target>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        var reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.equal(reslist[0].getSource(), "seg1 seg2 seg3");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "huzzah");
-        test.equal(reslist[0].getPath(), "foo/bar/j.java");
-        test.equal(reslist[0].getProject(), "webapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), "2");
-
-        test.equal(reslist[0].getTarget(), "This is segment 1. This is segment 2. This is segment 3.");
-        test.equal(reslist[0].getTargetLocale(), "fr-FR");
-
-        test.done();
-    },
-
-    testXliff20DeserializePreserveSourceWhitespace: function(test) {
-        test.expect(9);
-
-        var x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="es-US" xmlns:l="http://ilib-js.com/loctool">\n' +
-                '  <file original="UI/AddAnotherButtonView.m" l:project="iosapp">\n' +
-                '    <unit id="196" name="      Add Another" type="res:string" l:datatype="x-objective-c">\n' +
-                '      <segment>\n' +
-                '        <source>      Add Another</source>\n' +
-                '        <target>Añadir Otro</target>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        var reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.equal(reslist[0].getSource(), "      Add Another");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "      Add Another");
-        test.equal(reslist[0].getPath(), "UI/AddAnotherButtonView.m");
-        test.equal(reslist[0].getProject(), "iosapp");
-        test.equal(reslist[0].resType, "string");
-
-        test.done();
-    },
-
-    testXliff20DeserializePreserveTargetWhitespace: function(test) {
-        test.expect(9);
-
-        var x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="es-US" xmlns:l="http://ilib-js.com/loctool">\n' +
-                '  <file original="UI/AddAnotherButtonView.m" l:project="iosapp">\n' +
-                '    <unit id="196" name="      Add Another" type="res:string" l:datatype="x-objective-c">\n' +
-                '      <segment>\n' +
-                '        <source>      Add Another</source>\n' +
-                '        <target> Añadir    Otro  </target>\n' +
-                '      </segment>\n' +
-                '    </unit>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        var reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.equal(reslist[0].getTarget(), " Añadir    Otro  ");
-        test.equal(reslist[0].getTargetLocale(), "es-US");
-        test.equal(reslist[0].getKey(), "      Add Another");
-        test.equal(reslist[0].getPath(), "UI/AddAnotherButtonView.m");
-        test.equal(reslist[0].getProject(), "iosapp");
-        test.equal(reslist[0].resType, "string");
-
-        test.done();
-    },
-
-    testXliff20AddTranslationUnit: function(test) {
-        test.expect(10);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        var reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.equal(reslist[0].getSource(), "a");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "/a/b/asdf.js");
-        test.equal(reslist[0].getProject(), "iosapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), 2334);
-
-        test.done();
-    },
-
-    testXliff20AddTranslationUnitMergeResources: function(test) {
-        test.expect(12);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "b",
-            "targetLocale": "fr-FR",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        var reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-
-        test.equal(reslist[0].getSource(), "a");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getTarget(), "b");
-        test.equal(reslist[0].getTargetLocale(), "fr-FR");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "/a/b/asdf.js");
-        test.equal(reslist[0].getProject(), "iosapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].getId(), 2334);
-
-        test.done();
-    },
-
-    testXliff20AddTranslationUnitAddMultipleUnits: function(test) {
-        test.expect(3);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "bababa",
-            "sourceLocale": "en-US",
-            "target": "ababab",
-            "targetLocale": "fr-FR",
-            "key": "asdf",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2333,
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "b",
-            "targetLocale": "fr-FR",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        var units = x.getTranslationUnits();
-
-        test.ok(units);
-
-        test.equal(units.length, 2);
-
-        test.done();
-    },
-
-    testXliff20AddTranslationUnitReplacePreviousUnit: function(test) {
-        test.expect(3);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "b",
-            "targetLocale": "fr-FR",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "ab",
-            "sourceLocale": "en-US",
-            "target": "ba",
-            "targetLocale": "fr-FR",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a new comment"
-        }));
-
-        var units = x.getTranslationUnits();
-
-        test.ok(units);
-
-        // should have merged them into 1 unit because the signature was the same
-        test.equal(units.length, 1);
-
-        test.done();
-    },
-
-    testXliff20AddTranslationUnitRightContents: function(test) {
-        test.expect(15);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "b",
-            "targetLocale": "fr-FR",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "ab",
-            "sourceLocale": "en-US",
-            "target": "ba",
-            "targetLocale": "fr-FR",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a new comment"
-        }));
-
-        var units = x.getTranslationUnits();
-
-        test.ok(units);
-
-        test.equal(units.length, 1);
-
-        test.equal(units[0].source, "ab");
-        test.equal(units[0].sourceLocale, "en-US");
-        test.equal(units[0].target, "ba");
-        test.equal(units[0].targetLocale, "fr-FR");
-        test.equal(units[0].key, "foobar");
-        test.equal(units[0].file, "/a/b/asdf.js");
-        test.equal(units[0].project, "iosapp");
-        test.equal(units[0].id, 2334);
-        test.equal(units[0].resType, "string");
-        test.equal(units[0].origin, "source");
-        test.equal(units[0].context, "asdfasdf");
-        test.equal(units[0].comment, "this is a new comment");
-
-        test.done();
-    },
-
-    testXliff20AddTranslationUnitRightResourceTypesRegularString: function(test) {
-        test.expect(4);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "b",
-            "targetLocale": "fr-FR",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType": "string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a comment",
-            "datatype": "javascript"
-        }));
-
-        var resources = x.getResources();
-
-        test.ok(resources);
-
-        test.equal(resources.length, 1);
-
-        test.ok(resources[0] instanceof ResourceString);
-
-        test.done();
-    },
-
-    testXliff20AddTranslationUnitRightResourceTypesContextString: function(test) {
-        test.expect(5);
-
-        ResourceFactory.registerDataType("x-android-resource", "string", ContextResourceString);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "ba",
-            "targetLocale": "fr-FR",
-            "key": "foobar",
-            "file": "/a/b/asdf.xml",
-            "project": "androidapp",
-            "id": 2334,
-            "resType":"string",
-            "comment": "this is a comment",
-            "datatype": "x-android-resource",
-            "flavor": "chocolate"
-        }));
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "baa",
-            "targetLocale": "fr-FR",
-            "key": "foobar",
-            "file": "/a/b-x/asdf.xml",
-            "project": "androidapp",
-            "id": 2334,
-            "resType": "string",
-            "context": "x",
-            "comment": "this is a new comment",
-            "datatype": "x-android-resource",
-            "flavor": "chocolate"
-        }));
-
-        var resources = x.getResources();
-
-        test.ok(resources);
-
-        test.equal(resources.length, 2);
-
-        test.ok(resources[0] instanceof ContextResourceString);
-        test.ok(resources[1] instanceof ContextResourceString);
-
-        test.done();
-    },
-
-    testXliff20AddTranslationUnitReplaceSourceOnlyUnit: function(test) {
-        test.expect(3);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType": "string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "b",
-            "targetLocale": "fr-FR",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        var units = x.getTranslationUnits();
-
-        test.ok(units);
-
-        // should have merged them into 1 unit because the signature was the same
-        test.equal(units.length, 1);
-
-        test.done();
-    },
-
-    testXliff20AddTranslationUnitDifferentPathsRightTypes: function(test) {
-        test.expect(5);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        ResourceFactory.registerDataType("x-xib", "string", IosLayoutResourceString);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "foo",
-            "targetLocale": "de-DE",
-            "key": "foobar",
-            "file": "a/b/asdf.xib",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "origin": "target",
-            "comment": "this is a comment",
-            "datatype": "x-xib"
-        }));
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "foo",
-            "targetLocale": "de-DE",
-            "key": "foobar",
-            "file": "a/b/asdf~ipad.xib",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "origin": "target",
-            "comment": "this is a comment",
-            "datatype": "x-xib"
-        }));
-
-        var resources = x.getResources();
-
-        test.ok(resources);
-
-        test.equal(resources.length, 2);
-
-        test.ok(resources[0] instanceof IosLayoutResourceString);
-        test.ok(resources[1] instanceof IosLayoutResourceString);
-
-        test.done();
-    },
-
-    testXliff20AddTranslationUnitDifferentPaths: function(test) {
-        test.expect(23);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        ResourceFactory.registerDataType("x-xib", "string", IosLayoutResourceString);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "foo",
-            "targetLocale": "de-DE",
-            "key": "foobar",
-            "file": "a/b/asdf.xib",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "comment": "this is a comment",
-            "datatype": "x-xib"
-        }));
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "foo",
-            "targetLocale": "de-DE",
-            "key": "foobar",
-            "file": "a/b/asdf~ipad.xib",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "comment": "this is a comment",
-            "datatype": "x-xib"
-        }));
-
-        var reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 2);
-
-        test.equal(reslist[0].getSource(), "a");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getTarget(), "foo");
-        test.equal(reslist[0].getTargetLocale(), "de-DE");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "a/b/asdf.xib");
-        test.equal(reslist[0].getProject(), "iosapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].datatype, "x-xib");
-        test.equal(reslist[0].getId(), 2334);
-
-        test.equal(reslist[1].getSource(), "a");
-        test.equal(reslist[1].getSourceLocale(), "en-US");
-        test.equal(reslist[1].getTarget(), "foo");
-        test.equal(reslist[1].getTargetLocale(), "de-DE");
-        test.equal(reslist[1].getKey(), "foobar");
-        test.equal(reslist[1].getPath(), "a/b/asdf~ipad.xib");
-        test.equal(reslist[1].getProject(), "iosapp");
-        test.equal(reslist[1].resType, "string");
-        test.equal(reslist[1].datatype, "x-xib");
-        test.equal(reslist[1].getId(), 2334);
-
-        test.done();
-    },
-
-    testXliff20SerializeWithTranslationUnits: function(test) {
-        test.expect(2);
-
-        var x = new Xliff({version: "2.0"});
-        test.ok(x);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "bababa",
-            "sourceLocale": "en-US",
-            "target": "ababab",
-            "targetLocale": "fr-FR",
-            "key": "asdf",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2333,
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "a",
-            "sourceLocale": "en-US",
-            "target": "b",
-            "targetLocale": "fr-FR",
-            "key": "foobar",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        var expected =
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff version="2.0" srcLang="en-US" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">\n' +
-                '  <file original="/a/b/asdf.js" l:project="iosapp">\n' +
-                '    <group id="group_1" name="plaintext">\n' +
-                '      <unit id="2333" name="asdf" type="res:string" l:context="asdfasdf">\n' +
-                '        <notes>\n' +
-                '          <note appliesTo="source">this is a comment</note>\n' +
-                '        </notes>\n' +
+                '    <group id="group_2" name="plaintext">\n' +
+                '      <unit id="2" name="asdf \\t\\n\\n asdf\\n" type="res:string" l:datatype="plaintext">\n' +
                 '        <segment>\n' +
-                '          <source>bababa</source>\n' +
-                '          <target>ababab</target>\n' +
-                '        </segment>\n' +
-                '      </unit>\n' +
-                '      <unit id="2334" name="foobar" type="res:string" l:context="asdfasdf">\n' +
-                '        <notes>\n' +
-                '          <note appliesTo="source">this is a comment</note>\n' +
-                '        </notes>\n' +
-                '        <segment>\n' +
-                '          <source>a</source>\n' +
-                '          <target>b</target>\n' +
+                '          <source>asdf \\t\\n\\n</source>\n' +
+                '          <target>fdsa \\t\\n\\n fdsa\\n</target>\n' +
                 '        </segment>\n' +
                 '      </unit>\n' +
                 '    </group>\n' +
                 '  </file>\n' +
                 '</xliff>';
 
-        diff(x.serialize(), expected);
-        test.equal(x.serialize(), expected);
-
+        diff(actual, expected);
+        test.equal(actual, expected);
         test.done();
     },
 
@@ -3110,330 +928,705 @@ export const testXliff20 = {
         test.done();
     },
 
-    testXliff20AddResourcesWithInstances: function(test) {
-        test.expect(9);
-
-        var x = new Xliff({
-            version: "2.0",
-            allowDups: true
-        });
-        test.ok(x);
-
-        var res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp"
-        });
-
-        var res2 = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp",
-            comment: "special translators note"
-        });
-        res.addInstance(res2);
-
-        x.addResource(res);
-
-        var reslist = x.getResources({
-            reskey: "foobar"
-        });
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-        test.equal(reslist[0].getSource(), "Asdf asdf");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "webapp");
-        test.ok(!reslist[0].getComment());
-
-        test.done();
-    },
-
-    testXliff20AddMultipleResourcesAddInstances: function(test) {
-        test.expect(17);
-
-        var x = new Xliff({
-            version: "2.0",
-            allowDups: true
-        });
-        test.ok(x);
-
-        var res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        // this one has the same source, locale, key, and file
-        // so it should create an instance of the first one
-        res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            comment: "blah blah blah",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        var reslist = x.getResources({
-            reskey: "foobar"
-        });
-
-        test.ok(reslist);
-
-        test.equal(reslist.length, 1);
-        test.equal(reslist[0].getSource(), "Asdf asdf");
-        test.equal(reslist[0].getSourceLocale(), "en-US");
-        test.equal(reslist[0].getKey(), "foobar");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "webapp");
-        test.ok(!reslist[0].getComment());
-
-        var instances = reslist[0].getInstances();
-        test.ok(instances);
-        test.equal(instances.length, 1);
-
-        test.equal(instances[0].getSource(), "Asdf asdf");
-        test.equal(instances[0].getSourceLocale(), "en-US");
-        test.equal(instances[0].getKey(), "foobar");
-        test.equal(instances[0].getPath(), "foo/bar/asdf.java");
-        test.equal(instances[0].getProject(), "webapp");
-        test.equal(instances[0].getComment(), "blah blah blah");
-
-        test.done();
-    },
-
-    testXliff20SerializeWithResourcesWithInstancesWithNoTarget: function(test) {
-        test.expect(2);
-
-        var x = new Xliff({
-            version: "2.0",
-            allowDups: true
-        });
-        test.ok(x);
-
-        var res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        // this one has the same source, locale, key, and file
-        // so it should create an instance of the first one
-        res = new ResourceString({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            key: "foobar",
-            pathName: "foo/bar/asdf.java",
-            comment: "blah blah blah",
-            project: "webapp"
-        });
-
-        x.addResource(res);
-
-        var expected =
-            '<?xml version="1.0" encoding="utf-8"?>\n' +
-            '<xliff version="2.0" srcLang="en-US" xmlns:l="http://ilib-js.com/loctool">\n' +
-            '  <file original="foo/bar/asdf.java" l:project="webapp">\n' +
-            '    <group id="group_1" name="plaintext">\n' +
-            '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
-            '        <segment>\n' +
-            '          <source>Asdf asdf</source>\n' +
-            '        </segment>\n' +
-            '      </unit>\n' +
-            '      <unit id="2" name="foobar" type="res:string" l:datatype="plaintext">\n' +
-            '        <notes>\n' +
-            '          <note appliesTo="source">blah blah blah</note>\n' +
-            '        </notes>\n' +
-            '        <segment>\n' +
-            '          <source>Asdf asdf</source>\n' +
-            '        </segment>\n' +
-            '      </unit>\n' +
-            '    </group>\n' +
-            '  </file>\n' +
-            '</xliff>';
-
-        var actual = x.serialize();
-        diff(actual, expected);
-
-        test.equal(actual, expected);
-
-        test.done();
-    },
-
-    testXliff20SerializeWithTranslationUnitsWithInstances: function(test) {
-        test.expect(2);
-
-        var x = new Xliff({
-            version: "2.0",
-            allowDups: true
-        });
-        test.ok(x);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "bababa",
-            "sourceLocale": "en-US",
-            "target": "ababab",
-            "targetLocale": "fr-FR",
-            "key": "asdf",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2333,
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a comment"
-        }));
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "bababa",
-            "sourceLocale": "en-US",
-            "target": "ababab",
-            "targetLocale": "fr-FR",
-            "key": "asdf",
-            "file": "/a/b/asdf.js",
-            "project": "iosapp",
-            "id": 2334,
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a different comment"
-        }));
-
-        var expected =
-            '<?xml version="1.0" encoding="utf-8"?>\n' +
-            '<xliff version="2.0" srcLang="en-US" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">\n' +
-            '  <file original="/a/b/asdf.js" l:project="iosapp">\n' +
-            '    <group id="group_1" name="plaintext">\n' +
-            '      <unit id="2333" name="asdf" type="res:string" l:context="asdfasdf">\n' +
-            '        <notes>\n' +
-            '          <note appliesTo="source">this is a comment</note>\n' +
-            '        </notes>\n' +
-            '        <segment>\n' +
-            '          <source>bababa</source>\n' +
-            '          <target>ababab</target>\n' +
-            '        </segment>\n' +
-            '      </unit>\n' +
-            '      <unit id="2334" name="asdf" type="res:string" l:context="asdfasdf">\n' +
-            '        <notes>\n' +
-            '          <note appliesTo="source">this is a different comment</note>\n' +
-            '        </notes>\n' +
-            '        <segment>\n' +
-            '          <source>bababa</source>\n' +
-            '          <target>ababab</target>\n' +
-            '        </segment>\n' +
-            '      </unit>\n' +
-            '    </group>\n' +
-            '  </file>\n' +
-            '</xliff>';
-
-        var actual = x.serialize();
-        diff(actual, expected);
-
-        test.equal(actual, expected);
-
-        test.done();
-    },
-
-    testXliff20SerializeWithTranslationUnitsWithTypes: function(test) {
-        test.expect(2);
-
-        var x = new Xliff({
-            version: "2.0",
-            allowDups: true
-        });
-        test.ok(x);
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "bababa",
-            "sourceLocale": "en-US",
-            "target": "ababab",
-            "targetLocale": "fr-FR",
-            "key": "asdf",
-            "file": "/a/b/asdf.js",
-            "project": "webapp1",
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a comment",
-            "datatype": "javascript"
-        }));
-
-        x.addTranslationUnit(new TranslationUnit({
-            "source": "bababa",
-            "sourceLocale": "en-US",
-            "target": "ababab",
-            "targetLocale": "fr-FR",
-            "key": "asdf",
-            "file": "/a/b/asdf.js",
-            "project": "webapp1",
-            "resType":"string",
-            "origin": "source",
-            "context": "asdfasdf",
-            "comment": "this is a different comment",
-            "datatype": "x-json"
-        }));
-
-        var expected =
-            '<?xml version="1.0" encoding="utf-8"?>\n' +
-            '<xliff version="2.0" srcLang="en-US" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">\n' +
-            '  <file original="/a/b/asdf.js" l:project="webapp1">\n' +
-            '    <group id="group_1" name="javascript">\n' +
-            '      <unit id="1" name="asdf" type="res:string" l:datatype="javascript" l:context="asdfasdf">\n' +
-            '        <notes>\n' +
-            '          <note appliesTo="source">this is a comment</note>\n' +
-            '        </notes>\n' +
-            '        <segment>\n' +
-            '          <source>bababa</source>\n' +
-            '          <target>ababab</target>\n' +
-            '        </segment>\n' +
-            '      </unit>\n' +
-            '    </group>\n' +
-            '    <group id="group_2" name="x-json">\n' +
-            '      <unit id="2" name="asdf" type="res:string" l:datatype="x-json" l:context="asdfasdf">\n' +
-            '        <notes>\n' +
-            '          <note appliesTo="source">this is a different comment</note>\n' +
-            '        </notes>\n' +
-            '        <segment>\n' +
-            '          <source>bababa</source>\n' +
-            '          <target>ababab</target>\n' +
-            '        </segment>\n' +
-            '      </unit>\n' +
-            '    </group>\n' +
-            '  </file>\n' +
-            '</xliff>';
-
-
-        var actual = x.serialize();
-        diff(actual, expected);
-
-        test.equal(actual, expected);
-
-        test.done();
-    },
-
-    testXliff20DeserializeCreateInstances: function(test) {
+    testXliff20DeserializeWithSourceOnly: function(test) {
         test.expect(21);
 
-        var x = new Xliff({
-            version: "2.0",
+        const x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" \n' +
+                '  xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
+                '      <segment>\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:string" l:datatype="plaintext">\n' +
+                '      <segment>\n' +
+                '        <source>baby baby</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 2);
+
+        test.equal(tulist[0].source, "Asdf asdf");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.ok(!tulist[0].target);
+        test.equal(tulist[0].targetLocale, "de-DE");
+        test.equal(tulist[0].key, "foobar");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].project, "androidapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "1");
+
+        test.equal(tulist[1].source, "baby baby");
+        test.equal(tulist[1].sourceLocale, "en-US");
+        test.ok(!tulist[1].target);
+        test.equal(tulist[1].targetLocale, "de-DE");
+        test.equal(tulist[1].key, "huzzah");
+        test.equal(tulist[1].file, "foo/bar/j.java");
+        test.equal(tulist[1].project, "webapp");
+        test.equal(tulist[1].resType, "string");
+        test.equal(tulist[1].id, "2");
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithSourceAndTarget: function(test) {
+        test.expect(21);
+
+        const x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '        <target>foobarfoo</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>baby baby</source>\n' +
+                '        <target>bebe bebe</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        // console.log("x is " + JSON.stringify(x, undefined, 4));
+        let tulist = x.getTranslationUnits();
+        // console.log("x is now " + JSON.stringify(x, undefined, 4));
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 2);
+
+        test.equal(tulist[0].source, "Asdf asdf");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "foobar");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].project, "androidapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "1");
+        test.equal(tulist[0].target, "foobarfoo");
+        test.equal(tulist[0].targetLocale, "de-DE");
+
+        test.equal(tulist[1].source, "baby baby");
+        test.equal(tulist[1].sourceLocale, "en-US");
+        test.equal(tulist[1].key, "huzzah");
+        test.equal(tulist[1].file, "foo/bar/j.java");
+        test.equal(tulist[1].project, "webapp");
+        test.equal(tulist[1].resType, "string");
+        test.equal(tulist[1].id, "2");
+        test.equal(tulist[1].target, "bebe bebe");
+        test.equal(tulist[1].targetLocale, "de-DE");
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithXMLUnescaping: function(test) {
+        test.expect(19);
+
+        const x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" xmlns:l="http://ilib-js.com/loctool" srcLang="en-US">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>Asdf &lt;b&gt;asdf&lt;/b&gt;</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>baby &amp;lt;b&amp;gt;baby&amp;lt;/b&amp;gt;</source>\n' +   // double escaped!
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 2);
+
+        test.equal(tulist[0].source, "Asdf <b>asdf</b>");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "foobar");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].project, "androidapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "1");
+        test.ok(!tulist[0].target);
+
+        test.equal(tulist[1].source, "baby &lt;b&gt;baby&lt;/b&gt;");
+        test.equal(tulist[1].sourceLocale, "en-US");
+        test.equal(tulist[1].key, "huzzah");
+        test.equal(tulist[1].file, "foo/bar/j.java");
+        test.equal(tulist[1].project, "webapp");
+        test.equal(tulist[1].resType, "string");
+        test.equal(tulist[1].id, "2");
+        test.ok(!tulist[1].target);
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithXMLUnescapingInResname: function(test) {
+        test.expect(19);
+
+        const x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" xmlns:l="http://ilib-js.com/loctool" srcLang="en-US">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar &lt;a>link&lt;/a>" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>Asdf &lt;b&gt;asdf&lt;/b&gt;</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="&lt;b>huzzah&lt;/b>" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>baby &amp;lt;b&amp;gt;baby&amp;lt;/b&amp;gt;</source>\n' +   // double escaped!
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 2);
+
+        test.equal(tulist[0].source, "Asdf <b>asdf</b>");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "foobar <a>link</a>");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].project, "androidapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "1");
+        test.ok(!tulist[0].target);
+
+        test.equal(tulist[1].source, "baby &lt;b&gt;baby&lt;/b&gt;");
+        test.equal(tulist[1].sourceLocale, "en-US");
+        test.equal(tulist[1].key, "<b>huzzah</b>");
+        test.equal(tulist[1].file, "foo/bar/j.java");
+        test.equal(tulist[1].project, "webapp");
+        test.equal(tulist[1].resType, "string");
+        test.equal(tulist[1].id, "2");
+        test.ok(!tulist[1].target);
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithEscapedNewLines: function(test) {
+        test.expect(17);
+
+        const x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="en-CA" \n' +
+                '  xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>a\\nb</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>e\\nh</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 2);
+
+        test.equal(tulist[0].source, "a\\nb");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "foobar");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].project, "androidapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "1");
+
+        test.equal(tulist[1].source, "e\\nh");
+        test.equal(tulist[1].sourceLocale, "en-US");
+        test.equal(tulist[1].key, "huzzah");
+        test.equal(tulist[1].file, "foo/bar/j.java");
+        test.equal(tulist[1].project, "webapp");
+        test.equal(tulist[1].resType, "string");
+        test.equal(tulist[1].id, "2");
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithEscapedNewLinesInResname: function(test) {
+        test.expect(17);
+
+        const x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="en-CA" \n' +
+                '  xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar\\nbar\\t" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>a\\nb</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah\\n\\na plague on both your houses" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>e\\nh</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 2);
+
+        test.equal(tulist[0].source, "a\\nb");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "foobar\\nbar\\t");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].project, "androidapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "1");
+
+        test.equal(tulist[1].source, "e\\nh");
+        test.equal(tulist[1].sourceLocale, "en-US");
+        test.equal(tulist[1].key, "huzzah\\n\\na plague on both your houses");
+        test.equal(tulist[1].file, "foo/bar/j.java");
+        test.equal(tulist[1].project, "webapp");
+        test.equal(tulist[1].resType, "string");
+        test.equal(tulist[1].id, "2");
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithContext: function(test) {
+        test.expect(19);
+
+        const x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar" type="res:string" l:context="na na na">\n' +
+                '      <segment>\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:string" l:context="asdf">\n' +
+                '      <segment>\n' +
+                '        <source>baby baby</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 2);
+
+        test.equal(tulist[0].source, "Asdf asdf");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "foobar");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].project, "androidapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "1");
+        test.equal(tulist[0].context, "na na na");
+
+        test.equal(tulist[1].source, "baby baby");
+        test.equal(tulist[1].sourceLocale, "en-US");
+        test.equal(tulist[1].key, "huzzah");
+        test.equal(tulist[1].file, "foo/bar/j.java");
+        test.equal(tulist[1].project, "webapp");
+        test.equal(tulist[1].resType, "string");
+        test.equal(tulist[1].id, "2");
+        test.equal(tulist[1].context, "asdf");
+
+        test.done();
+    },
+
+    testXliff20DeserializeEmptySource: function(test) {
+        test.expect(12);
+
+        const x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar" type="res:string" l:context="na na na">\n' +
+                '      <segment>\n' +
+                '        <source></source>\n' +
+                '        <target>Baby Baby</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>baby baby</source>\n' +
+                '        <target>bebe bebe</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+
+        test.equal(tulist[0].source, "baby baby");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "huzzah");
+        test.equal(tulist[0].file, "foo/bar/j.java");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "2");
+
+        test.equal(tulist[0].target, "bebe bebe");
+        test.equal(tulist[0].targetLocale, "fr-FR");
+
+        test.done();
+    },
+
+    testXliff20DeserializeEmptyTarget: function(test) {
+        test.expect(17);
+
+        const x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>baby baby</source>\n' +
+                '        <target></target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 2);
+
+        test.equal(tulist[0].source, "Asdf asdf");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "foobar");
+        test.equal(tulist[0].file, "foo/bar/asdf.java");
+        test.equal(tulist[0].project, "androidapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "1");
+
+        test.equal(tulist[1].source, "baby baby");
+        test.equal(tulist[1].sourceLocale, "en-US");
+        test.equal(tulist[1].key, "huzzah");
+        test.equal(tulist[1].file, "foo/bar/j.java");
+        test.equal(tulist[1].project, "webapp");
+        test.equal(tulist[1].resType, "string");
+        test.equal(tulist[1].id, "2");
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithMrkTagInTarget: function(test) {
+        test.expect(12);
+
+        const x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        x.deserialize(
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="2.0" srcLang="en-US" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">\n' +
+            '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+            '    <unit id="2" name="huzzah" type="res:string">\n' +
+            '      <segment>\n' +
+            '        <source>baby baby</source>\n' +
+            '        <seg-source><mrk mtype="seg" mid="4">baby baby</mrk></seg-source>\n' +
+            '        <target><mrk mtype="seg" mid="4">bebe bebe</mrk></target>\n' +
+            '      </segment>\n' +
+            '    </unit>\n' +
+            '  </file>\n' +
+            '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+
+        test.equal(tulist[0].source, "baby baby");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "huzzah");
+        test.equal(tulist[0].file, "foo/bar/j.java");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "2");
+        test.equal(tulist[0].target, "bebe bebe");
+        test.equal(tulist[0].targetLocale, "fr-FR");
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithEmptyMrkTagInTarget: function(test) {
+        test.expect(10);
+
+        const x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>baby baby</source>\n' +
+                '        <seg-source><mrk mtype="seg" mid="4">baby baby</mrk></seg-source>\n' +
+                '        <target><mrk mtype="seg" mid="4"></mrk></target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+
+        test.equal(tulist[0].source, "baby baby");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "huzzah");
+        test.equal(tulist[0].file, "foo/bar/j.java");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "2");
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithMultipleMrkTagsInTargetEuro: function(test) {
+        test.expect(12);
+
+        const x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>baby baby</source>\n' +
+                '        <seg-source><mrk mtype="seg" mid="4">baby baby</mrk></seg-source>\n' +
+                '        <target><mrk mtype="seg" mid="4">This is segment 1.</mrk> <mrk mtype="seg" mid="5">This is segment 2.</mrk> <mrk mtype="seg" mid="6">This is segment 3.</mrk></target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+
+        test.equal(tulist[0].source, "baby baby");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "huzzah");
+        test.equal(tulist[0].file, "foo/bar/j.java");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "2");
+
+        test.equal(tulist[0].target, "This is segment 1. This is segment 2. This is segment 3.");
+        test.equal(tulist[0].targetLocale, "fr-FR");
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithMultipleMrkTagsInTargetAsian: function(test) {
+        test.expect(12);
+
+        const x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="zh-Hans-CN" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>baby baby</source>\n' +
+                '        <seg-source><mrk mtype="seg" mid="4">baby baby</mrk></seg-source>\n' +
+                '        <target><mrk mtype="seg" mid="4">This is segment 1.</mrk> <mrk mtype="seg" mid="5">This is segment 2.</mrk> <mrk mtype="seg" mid="6">This is segment 3.</mrk></target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+
+        test.equal(tulist[0].source, "baby baby");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "huzzah");
+        test.equal(tulist[0].file, "foo/bar/j.java");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "2");
+
+        test.equal(tulist[0].target, "This is segment 1.This is segment 2.This is segment 3.");
+        test.equal(tulist[0].targetLocale, "zh-Hans-CN");
+
+        test.done();
+    },
+
+    testXliff20DeserializePreserveSourceWhitespace: function(test) {
+        test.expect(9);
+
+        const x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="es-US" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="UI/AddAnotherButtonView.m" l:project="iosapp">\n' +
+                '    <unit id="196" name="      Add Another" type="res:string" l:datatype="x-objective-c">\n' +
+                '      <segment>\n' +
+                '        <source>      Add Another</source>\n' +
+                '        <target>Añadir Otro</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+
+        test.equal(tulist[0].source, "      Add Another");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "      Add Another");
+        test.equal(tulist[0].file, "UI/AddAnotherButtonView.m");
+        test.equal(tulist[0].project, "iosapp");
+        test.equal(tulist[0].resType, "string");
+
+        test.done();
+    },
+
+    testXliff20DeserializePreserveTargetWhitespace: function(test) {
+        test.expect(9);
+
+        const x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="es-US" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="UI/AddAnotherButtonView.m" l:project="iosapp">\n' +
+                '    <unit id="196" name="      Add Another" type="res:string" l:datatype="x-objective-c">\n' +
+                '      <segment>\n' +
+                '        <source>      Add Another</source>\n' +
+                '        <target> Añadir    Otro  </target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+
+        test.equal(tulist[0].target, " Añadir    Otro  ");
+        test.equal(tulist[0].targetLocale, "es-US");
+        test.equal(tulist[0].key, "      Add Another");
+        test.equal(tulist[0].file, "UI/AddAnotherButtonView.m");
+        test.equal(tulist[0].project, "iosapp");
+        test.equal(tulist[0].resType, "string");
+
+        test.done();
+    },
+
+    testXliff20DeserializeStillAcceptsAnnotatesAttr: function(test) {
+        test.expect(19);
+
+        const x = new Xliff({
             allowDups: true
         });
         test.ok(x);
@@ -3453,7 +1646,7 @@ export const testXliff20 = {
             '    </unit>\n' +
             '    <unit id="2334" name="asdf" type="res:string" l:context="asdfasdf">\n' +
             '      <notes>\n' +
-            '        <note appliesTo="source">this is a different comment</note>\n' +
+            '        <note appliesTo="target">this is a different comment</note>\n' +
             '      </notes>\n' +
             '      <segment>\n' +
             '        <source>bababa</source>\n' +
@@ -3463,149 +1656,30 @@ export const testXliff20 = {
             '  </file>\n' +
             '</xliff>');
 
-        var reslist = x.getResources();
+        let tulist = x.getTranslationUnits();
 
-        test.ok(reslist);
+        test.ok(tulist);
 
-        test.equal(reslist.length, 1);
+        test.equal(tulist.length, 2);
 
-        test.equal(reslist[0].getTarget(), "ababab");
-        test.equal(reslist[0].getTargetLocale(), "fr-FR");
-        test.equal(reslist[0].getKey(), "asdf");
-        test.equal(reslist[0].getPath(), "/a/b/asdf.js");
-        test.equal(reslist[0].getProject(), "iosapp");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].context, "asdfasdf");
-        test.equal(reslist[0].comment, "this is a comment");
+        test.equal(tulist[0].target, "ababab");
+        test.equal(tulist[0].targetLocale, "fr-FR");
+        test.equal(tulist[0].key, "asdf");
+        test.equal(tulist[0].file, "/a/b/asdf.js");
+        test.equal(tulist[0].project, "iosapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].context, "asdfasdf");
+        test.equal(tulist[0].comment, "this is a comment");
 
-        var instances = reslist[0].getInstances();
-        test.ok(instances);
-        test.equal(instances.length, 1);
-
-        test.equal(instances[0].getTarget(), "ababab");
-        test.equal(instances[0].getTargetLocale(), "fr-FR");
-        test.equal(instances[0].getKey(), "asdf");
-        test.equal(instances[0].getPath(), "/a/b/asdf.js");
-        test.equal(instances[0].getProject(), "iosapp");
-        test.equal(instances[0].resType, "string");
-        test.equal(instances[0].context, "asdfasdf");
-        test.equal(instances[0].comment, "this is a different comment");
-
-        test.done();
-    },
-
-    testXliff20DeserializeLGStyleXliff: function(test) {
-        test.expect(24);
-
-        var x = new Xliff();
-        test.ok(x);
-
-        x.deserialize(
-                '<?xml version="1.0" encoding="utf-8"?>\n' +
-                '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-KR" trgLang="ko-KR">\n' +
-                '  <file id="f1" original="foo/bar/asdf.java" >\n' +
-                '    <group id="g1" name="javascript">\n' +
-                '      <unit id="1">\n' +
-                '        <segment>\n' +
-                '          <source>Closed Caption Settings</source>\n' +
-                '          <target>자막 설정</target>\n' +
-                '        </segment>\n' +
-                '      </unit>\n' +
-                '      <unit id="2">\n' +
-                '        <segment>\n' +
-                '          <source>Low</source>\n' +
-                '          <target>낮음</target>\n' +
-                '        </segment>\n' +
-                '      </unit>\n' +
-                '    </group>\n' +
-                '  </file>\n' +
-                '</xliff>');
-
-        var reslist = x.getResources();
-
-        test.ok(reslist);
-
-        test.equal(reslist[0].getSource(), "Closed Caption Settings");
-        test.equal(reslist[0].getSourceLocale(), "en-KR");
-        test.equal(reslist[0].getTarget(), "자막 설정");
-        test.equal(reslist[0].getTargetLocale(), "ko-KR");
-        test.equal(reslist[0].getKey(), "Closed Caption Settings");
-        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[0].getProject(), "foo/bar/asdf.java");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].datatype, "javascript");
-        test.ok(!reslist[0].getComment());
-        test.equal(reslist[0].getId(), "1");
-
-        test.equal(reslist[1].getSource(), "Low");
-        test.equal(reslist[1].getSourceLocale(), "en-KR");
-        test.equal(reslist[1].getTarget(), "낮음");
-        test.equal(reslist[1].getTargetLocale(), "ko-KR");
-        test.equal(reslist[1].getKey(), "Low");
-        test.equal(reslist[1].getPath(), "foo/bar/asdf.java");
-        test.equal(reslist[1].getProject(), "foo/bar/asdf.java");
-        test.equal(reslist[1].resType, "string");
-        test.equal(reslist[1].datatype, "javascript");
-        test.ok(!reslist[1].getComment());
-        test.equal(reslist[1].getId(), "2");
-
-        test.done();
-    },
-
-    testXliff20DeserializeRealLGFile: function(test) {
-        test.expect(37);
-
-        var x = new Xliff();
-        test.ok(x);
-
-        var fs = require("fs");
-
-        var str = fs.readFileSync("testfiles/test5.xliff", "utf-8");
-
-        x.deserialize(str);
-
-        var reslist = x.getResources();
-        test.ok(reslist);
-        test.equal(reslist.length, 7);
-
-        test.equal(reslist[0].getSource(), "Closed Caption Settings");
-        test.equal(reslist[0].getSourceLocale(), "en-KR");
-        test.equal(reslist[0].getTarget(), "자막 설정");
-        test.equal(reslist[0].getTargetLocale(), "ko-KR");
-        test.equal(reslist[0].getKey(), "Closed Caption Settings");
-        test.equal(reslist[0].getPath(), "settings");
-        test.equal(reslist[0].getProject(), "settings");
-        test.equal(reslist[0].resType, "string");
-        test.equal(reslist[0].datatype, "javascript");
-        test.ok(!reslist[0].getComment());
-        test.equal(reslist[0].getId(), "settings_1");
-
-        test.equal(reslist[3].getSource(), "Low");
-        test.equal(reslist[3].getSourceLocale(), "en-KR");
-        test.equal(reslist[3].getTarget(), "낮음");
-        test.equal(reslist[3].getTargetLocale(), "ko-KR");
-        test.equal(reslist[3].getKey(), "pictureControlLow_Male");
-        test.equal(reslist[3].getPath(), "settings");
-        test.equal(reslist[3].getProject(), "settings");
-        test.equal(reslist[3].resType, "string");
-        test.equal(reslist[3].datatype, "javascript");
-        test.ok(!reslist[3].getComment());
-        test.equal(reslist[3].getId(), "settings_1524");
-
-        test.equal(reslist[6].getSource(), "SEARCH");
-        test.equal(reslist[6].getSourceLocale(), "en-KR");
-        test.equal(reslist[6].getTarget(), "검색");
-        test.equal(reslist[6].getTargetLocale(), "ko-KR");
-        test.equal(reslist[6].getKey(), "SEARCH");
-        test.equal(reslist[6].getPath(), "settings");
-        test.equal(reslist[6].getProject(), "settings");
-        test.equal(reslist[6].resType, "string");
-        test.equal(reslist[6].datatype, "x-qml");
-        test.ok(reslist[6].getComment());
-        test.equal(reslist[6].getComment(), "copy strings from voice app");
-        test.equal(reslist[6].getId(), "settings_22");
+        test.equal(tulist[1].target, "ababab");
+        test.equal(tulist[1].targetLocale, "fr-FR");
+        test.equal(tulist[1].key, "asdf");
+        test.equal(tulist[1].file, "/a/b/asdf.js");
+        test.equal(tulist[1].project, "iosapp");
+        test.equal(tulist[1].resType, "string");
+        test.equal(tulist[1].context, "asdfasdf");
+        test.equal(tulist[1].comment, "this is a different comment");
 
         test.done();
     }
-    */
 };

--- a/test/testXliff20.js
+++ b/test/testXliff20.js
@@ -1,0 +1,3611 @@
+/*
+ * testXliff20.js - test the Xliff 2.0 object.
+ *
+ * Copyright © 2022 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Xliff from "../src/Xliff.js";
+import TranslationUnit from "../src/TranslationUnit.js";
+
+function diff(a, b) {
+    var min = Math.min(a.length, b.length);
+
+    for (var i = 0; i < min; i++) {
+        if (a[i] !== b[i]) {
+            console.log("Found difference at character " + i);
+            console.log("a: " + a.substring(i));
+            console.log("b: " + b.substring(i));
+            break;
+        }
+    }
+}
+
+export const testXliff20 = {
+    testXliff20Constructor: function(test) {
+        test.expect(1);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        test.done();
+    },
+
+    testXliff20ConstructorIsEmpty: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        test.equal(x.size(), 0);
+        test.done();
+    },
+
+    testXliff20ConstructorRightVersion: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        test.equal(x.getVersion(), "2.0");
+        test.done();
+    },
+
+    testXliff20ConstructorNumericVersion12: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: 1.2});
+        test.ok(x);
+
+        test.equal(x.getVersion(), "1.2");
+        test.done();
+    },
+
+    testXliff20ConstructorNumericVersion20: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        test.equal(x.getVersion(), "2.0");
+        test.done();
+    },
+
+    testXliff20ConstructorFull: function(test) {
+        test.expect(8);
+
+        var x = new Xliff({
+            version: "2.0",
+            "tool-id": "loctool",
+            "tool-name": "Localization Tool",
+            "tool-version": "1.2.34",
+            "tool-company": "My Company, Inc.",
+            copyright: "Copyright 2016, My Company, Inc. All rights reserved.",
+            path: "a/b/c.xliff"
+        });
+        test.ok(x);
+
+        test.equal(x.getVersion(), "2.0");
+
+        test.equal(x["tool-id"], "loctool");
+        test.equal(x["tool-name"], "Localization Tool"),
+        test.equal(x["tool-version"], "1.2.34"),
+        test.equal(x["tool-company"], "My Company, Inc."),
+        test.equal(x.copyright, "Copyright 2016, My Company, Inc. All rights reserved."),
+        test.equal(x.path, "a/b/c.xliff");
+
+        test.done();
+    },
+/*
+    testXliff20AddResource: function(test) {
+        test.expect(11);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            comment: "this is a comment",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        var reslist = x.getResources({
+            reskey: "foobar"
+        });
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+        test.equal(reslist[0].getSource(), "Asdf asdf");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getState(), "new");
+        test.equal(reslist[0].getContext(), "asdf");
+        test.equal(reslist[0].getComment(), "this is a comment");
+        test.equal(reslist[0].getProject(), "webapp");
+
+        test.done();
+    },
+
+    testXliff20Size: function(test) {
+        test.expect(3);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            autoKey: false,
+            state: "new",
+            context: "asdf",
+            comment: "this is a comment",
+            project: "webapp"
+        });
+
+        test.equal(x.size(), 0);
+
+        x.addResource(res);
+
+        test.equal(x.size(), 1);
+
+        test.done();
+    },
+
+    testXliff20AddMultipleResources: function(test) {
+        test.expect(8);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        res = new ResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        var reslist = x.getResources({
+            reskey: "foobar"
+        });
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+        test.equal(reslist[0].getSource(), "Asdf asdf");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "webapp");
+
+        test.done();
+    },
+
+    testXliff20AddMultipleResourcesRightSize: function(test) {
+        test.expect(3);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+        test.equal(x.size(), 0);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        res = new ResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        test.equal(x.size(), 2);
+
+        test.done();
+    },
+
+    testXliff20AddMultipleResourcesOverwrite: function(test) {
+        test.expect(9);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        // this one has the same source, locale, key, and file
+        // so it should overwrite the one above
+        res = new ResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            comment: "blah blah blah",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        var reslist = x.getResources({
+            reskey: "foobar"
+        });
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+        test.equal(reslist[0].getSource(), "baby baby");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "webapp");
+        test.equal(reslist[0].getComment(), "blah blah blah");
+
+        test.done();
+    },
+
+    testXliff20AddMultipleResourcesOverwriteRightSize: function(test) {
+        test.expect(4);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        test.equal(x.size(), 0);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        test.equal(x.size(), 1);
+
+        // this one has the same source, locale, key, and file
+        // so it should overwrite the one above
+        res = new ResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            comment: "blah blah blah",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        test.equal(x.size(), 1);
+
+        test.done();
+    },
+
+    testXliff20AddMultipleResourcesNoOverwrite: function(test) {
+        test.expect(13);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        // this one has a different locale
+        // so it should not overwrite the one above
+        res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "fr-FR",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            comment: "blah blah blah",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        var reslist = x.getResources({
+            reskey: "foobar"
+        });
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 2);
+
+        test.equal(reslist[0].getSource(), "Asdf asdf");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.ok(!reslist[0].getComment());
+
+        test.equal(reslist[1].getSource(), "Asdf asdf");
+        test.equal(reslist[1].getSourceLocale(), "fr-FR");
+        test.equal(reslist[1].getKey(), "foobar");
+        test.equal(reslist[1].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[1].getComment(), "blah blah blah");
+
+        test.done();
+    },
+
+    testXliff20AddResourceDontAddSourceLocaleAsTarget: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({
+            version: "2.0",
+            sourceLocale: "en-US"
+        });
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        // should not add this one
+        res = new ResourceString({
+            source: "baby baby",
+            target: "babes babes",
+            targetLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        test.equal(x.size(), 1);
+
+        test.done();
+    },
+
+    testXliff20GetResourcesMultiple: function(test) {
+        test.expect(11);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp",
+            origin: "source"
+        });
+
+        x.addResource(res);
+
+        res = new ResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            origin: "origin"
+        });
+
+        x.addResource(res);
+
+        var reslist = x.getResources({
+            sourceLocale: "en-US"
+        });
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 2);
+
+        test.equal(reslist[0].getSource(), "Asdf asdf");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+
+        test.equal(reslist[1].getSource(), "baby baby");
+        test.equal(reslist[1].getSourceLocale(), "en-US");
+        test.equal(reslist[1].getKey(), "huzzah");
+        test.equal(reslist[1].getPath(), "foo/bar/j.java");
+
+        test.done();
+    },
+
+    testXliff20SerializeWithContext: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        var res = new ContextResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            target: "gutver",
+            targetLocale: "nl-NL",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            context: "foobar"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="2.0" srcLang="en-US" trgLang="nl-NL" xmlns:l="http://ilib-js.com/loctool">\n' +
+            '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+            '    <group id="group_1" name="plaintext">\n' +
+            '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext" l:context="foobar">\n' +
+            '        <segment>\n' +
+            '          <source>Asdf asdf</source>\n' +
+            '          <target>gutver</target>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '    </group>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliff20SerializeWithSourceOnly: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        var res = new ContextResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            targetLocale: "de-DE"
+        });
+
+        x.addResource(res);
+
+        res = new ContextResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            targetLocale: "de-DE"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+            '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+            '    <group id="group_1" name="plaintext">\n' +
+            '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
+            '        <segment>\n' +
+            '          <source>Asdf asdf</source>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '    </group>\n' +
+            '  </file>\n' +
+            '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+            '    <group id="group_2" name="plaintext">\n' +
+            '      <unit id="2" name="huzzah" type="res:string" l:datatype="plaintext">\n' +
+            '        <segment>\n' +
+            '          <source>baby baby</source>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '    </group>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+
+
+    },
+
+    testXliff20SerializediffrentFileSampePrj: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        var res = new ContextResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            targetLocale: "de-DE"
+        });
+
+        x.addResource(res);
+
+        res = new ContextResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "androidapp",
+            targetLocale: "de-DE"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+            '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+            '    <group id="group_1" name="plaintext">\n' +
+            '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
+            '        <segment>\n' +
+            '          <source>Asdf asdf</source>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '    </group>\n' +
+            '  </file>\n' +
+            '  <file original="foo/bar/j.java" l:project="androidapp">\n' +
+            '    <group id="group_2" name="plaintext">\n' +
+            '      <unit id="2" name="huzzah" type="res:string" l:datatype="plaintext">\n' +
+            '        <segment>\n' +
+            '          <source>baby baby</source>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '    </group>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliff20SerializeSampeFilesPrj: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        var res = new ContextResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            targetLocale: "de-DE"
+        });
+
+        x.addResource(res);
+
+        res = new ContextResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            targetLocale: "de-DE"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+            '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+            '    <group id="group_1" name="plaintext">\n' +
+            '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
+            '        <segment>\n' +
+            '          <source>Asdf asdf</source>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '      <unit id="2" name="huzzah" type="res:string" l:datatype="plaintext">\n' +
+            '        <segment>\n' +
+            '          <source>baby baby</source>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '    </group>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliff20SerializeWithSourceOnlyFilterOutWrongLocales: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        var res = new ContextResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            targetLocale: "de-DE"
+        });
+
+        x.addResource(res);
+
+        // should be filtered out because of the different target locale
+        res = new ContextResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            targetLocale: "fr-FR"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+            '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+            '    <group id="group_1" name="plaintext">\n' +
+            '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
+            '        <segment>\n' +
+            '          <source>Asdf asdf</source>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '    </group>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliff20SerializeWithFlavors: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        var res = new ContextResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            target: "gutver",
+            targetLocale: "nl-NL",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            origin: "source",
+            flavor: "chocolate"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected = '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="2.0" srcLang="en-US" trgLang="nl-NL" xmlns:l="http://ilib-js.com/loctool">\n' +
+            '  <file original="foo/bar/asdf.java" l:project="androidapp" l:flavor="chocolate">\n' +
+            '    <group id="group_1" name="plaintext">\n' +
+            '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
+            '        <segment>\n' +
+            '          <source>Asdf asdf</source>\n' +
+            '          <target>gutver</target>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '    </group>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliff20SerializeWithSourceOnlyAndPlurals: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        var res = new ContextResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            targetLocale: "de-DE"
+        });
+
+        x.addResource(res);
+
+        res = new ResourcePlural({
+            sourceStrings: {
+                "zero": "0",
+                "one": "1",
+                "few": "few"
+            },
+            sourceLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            targetLocale: "de-DE"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+            '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+            '    <group id="group_1" name="plaintext">\n' +
+            '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
+            '        <segment>\n' +
+            '          <source>Asdf asdf</source>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '    </group>\n' +
+            '  </file>\n' +
+            '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+            '    <group id="group_2" name="x-android-resource">\n' +
+            '      <unit id="2" name="huzzah" type="res:plural" l:datatype="x-android-resource" l:category="zero">\n' +
+            '        <notes>\n' +
+            '          <note appliesTo="source">{"pluralForm":"zero","pluralFormOther":"huzzah"}</note>\n' +
+            '        </notes>\n' +
+            '        <segment>\n' +
+            '          <source>0</source>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '      <unit id="3" name="huzzah" type="res:plural" l:datatype="x-android-resource" l:category="one">\n' +
+            '        <notes>\n' +
+            '          <note appliesTo="source">{"pluralForm":"one","pluralFormOther":"huzzah"}</note>\n' +
+            '        </notes>\n' +
+            '        <segment>\n' +
+            '          <source>1</source>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '      <unit id="4" name="huzzah" type="res:plural" l:datatype="x-android-resource" l:category="few">\n' +
+            '        <notes>\n' +
+            '          <note appliesTo="source">{"pluralForm":"few","pluralFormOther":"huzzah"}</note>\n' +
+            '        </notes>\n' +
+            '        <segment>\n' +
+            '          <source>few</source>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '    </group>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliff20SerializeWithSourceOnlyAndArray: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        var res = new ContextResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            targetLocale: "de-DE"
+        });
+
+        x.addResource(res);
+
+        res = new ResourceArray({
+            sourceArray: ["one", "two", "three"],
+            sourceLocale: "en-US",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            targetLocale: "de-DE"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+            '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+            '    <group id="group_1" name="plaintext">\n' +
+            '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
+            '        <segment>\n' +
+            '          <source>Asdf asdf</source>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '    </group>\n' +
+            '  </file>\n' +
+            '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+            '    <group id="group_2" name="x-android-resource">\n' +
+            '      <unit id="2" name="huzzah" type="res:array" l:datatype="x-android-resource" l:index="0">\n' +
+            '        <segment>\n' +
+            '          <source>one</source>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '      <unit id="3" name="huzzah" type="res:array" l:datatype="x-android-resource" l:index="1">\n' +
+            '        <segment>\n' +
+            '          <source>two</source>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '      <unit id="4" name="huzzah" type="res:array" l:datatype="x-android-resource" l:index="2">\n' +
+            '        <segment>\n' +
+            '          <source>three</source>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '    </group>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliff20SerializeWithExplicitIds: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            target: "baby baby",
+            targetLocale: "nl-NL",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            origin: "target",
+            id: 4444444
+        });
+
+        x.addResource(res);
+
+        res = new ResourceString({
+            source: "abcdef",
+            sourceLocale: "en-US",
+            target: "hijklmn",
+            targetLocale: "nl-NL",
+            key: "asdf",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="nl-NL" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <group id="group_1" name="plaintext">\n' +
+                '      <unit id="4444444" name="foobar" type="res:string" l:datatype="plaintext">\n' +
+                '        <segment>\n' +
+                '          <source>Asdf asdf</source>\n' +
+                '          <target>baby baby</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '      <unit id="4444445" name="asdf" type="res:string" l:datatype="plaintext">\n' +
+                '        <segment>\n' +
+                '          <source>abcdef</source>\n' +
+                '          <target>hijklmn</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '</xliff>';
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testXliff20SerializeWithSourceAndTarget: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            target: "foobarfoo",
+            targetLocale: "de-DE",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        res = new ResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            target: "bebe bebe",
+            targetLocale: "de-DE",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        var expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="webapp">\n' +
+                '    <group id="group_1" name="plaintext">\n' +
+                '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
+                '        <segment>\n' +
+                '          <source>Asdf asdf</source>\n' +
+                '          <target>foobarfoo</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <group id="group_2" name="plaintext">\n' +
+                '      <unit id="2" name="huzzah" type="res:string" l:datatype="plaintext">\n' +
+                '        <segment>\n' +
+                '          <source>baby baby</source>\n' +
+                '          <target>bebe bebe</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '</xliff>';
+
+        diff(x.serialize(), expected);
+        test.equal(x.serialize(), expected);
+
+        test.done();
+    },
+
+    testXliff20SerializeWithSourceAndTargetAndComment: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            target: "foobarfoo",
+            targetLocale: "de-DE",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp",
+            comment: "foobar is where it's at!"
+        });
+
+        x.addResource(res);
+
+        res = new ResourceString({
+            source: "baby baby",
+            sourceLocale: "en-US",
+            target: "bebe bebe",
+            targetLocale: "de-DE",
+            key: "huzzah",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            comment: "come & enjoy it with us"
+        });
+
+        x.addResource(res);
+
+        var expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="webapp">\n' +
+                '    <group id="group_1" name="plaintext">\n' +
+                '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
+                '        <notes>\n' +
+                '          <note appliesTo="source">foobar is where it\'s at!</note>\n' +
+                '        </notes>\n' +
+                '        <segment>\n' +
+                '          <source>Asdf asdf</source>\n' +
+                '          <target>foobarfoo</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <group id="group_2" name="plaintext">\n' +
+                '      <unit id="2" name="huzzah" type="res:string" l:datatype="plaintext">\n' +
+                '        <notes>\n' +
+                '          <note appliesTo="source">come &amp; enjoy it with us</note>\n' +
+                '        </notes>\n' +
+                '        <segment>\n' +
+                '          <source>baby baby</source>\n' +
+                '          <target>bebe bebe</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '</xliff>';
+
+        var actual = x.serialize();
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testXliff20SerializeWithHeader: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({
+            version: "2.0",
+            "tool-id": "loctool",
+            "tool-name": "Localization Tool",
+            "tool-version": "1.2.34",
+            "tool-company": "My Company, Inc.",
+            copyright: "Copyright 2016, My Company, Inc. All rights reserved.",
+            path: "a/b/c.xliff"
+        });
+        test.ok(x);
+
+        res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            target: "baby baby",
+            targetLocale: "nl-NL",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="nl-NL" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="webapp">\n' +
+                '    <group id="group_1" name="plaintext">\n' +
+                '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
+                '        <segment>\n' +
+                '          <source>Asdf asdf</source>\n' +
+                '          <target>baby baby</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '    <header>\n' +
+                '      <tool tool-id="loctool" tool-name="Localization Tool" tool-version="1.2.34" tool-company="My Company, Inc." copyright="Copyright 2016, My Company, Inc. All rights reserved."/>\n' +
+                '    </header>\n' +
+                '  </file>\n' +
+                '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliff20SerializeWithPlurals: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        res = new ResourcePlural({
+            sourceStrings: {
+                "one": "There is 1 object.",
+                "other": "There are {n} objects."
+            },
+            sourceLocale: "en-US",
+            targetStrings: {
+                "one": "Da gibts 1 Objekt.",
+                "other": "Da gibts {n} Objekten."
+            },
+            targetLocale: "de-DE",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            resType: "plural",
+            origin: "target",
+            autoKey: true,
+            state: "new",
+            datatype: "ruby"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <group id="group_1" name="ruby">\n' +
+                '      <unit id="1" name="foobar" type="res:plural" l:datatype="ruby" l:category="one">\n' +
+                '        <notes>\n' +
+                '          <note appliesTo="source">{"pluralForm":"one","pluralFormOther":"foobar"}</note>\n' +
+                '        </notes>\n' +
+                '        <segment>\n' +
+                '          <source>There is 1 object.</source>\n' +
+                '          <target state="new">Da gibts 1 Objekt.</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '      <unit id="2" name="foobar" type="res:plural" l:datatype="ruby" l:category="other">\n' +
+                '        <notes>\n' +
+                '          <note appliesTo="source">{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
+                '        </notes>\n' +
+                '        <segment>\n' +
+                '          <source>There are {n} objects.</source>\n' +
+                '          <target state="new">Da gibts {n} Objekten.</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '</xliff>';
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testXliff20SerializeWithPluralsToLangWithMorePluralsThanEnglish: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        res = new ResourcePlural({
+            sourceStrings: {
+                "one": "There is 1 object.",
+                "other": "There are {n} objects."
+            },
+            sourceLocale: "en-US",
+            targetStrings: {
+                "one": "Имеется {n} объект.",
+                "few": "Есть {n} объекта.",
+                "other": "Всего {n} объектов."
+            },
+            targetLocale: "ru-RU",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            resType: "plural",
+            origin: "target",
+            autoKey: true,
+            state: "new",
+            datatype: "ruby"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="ru-RU" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <group id="group_1" name="ruby">\n' +
+                '      <unit id="1" name="foobar" type="res:plural" l:datatype="ruby" l:category="one">\n' +
+                '        <notes>\n' +
+                '          <note appliesTo="source">{"pluralForm":"one","pluralFormOther":"foobar"}</note>\n' +
+                '        </notes>\n' +
+                '        <segment>\n' +
+                '          <source>There is 1 object.</source>\n' +
+                '          <target state="new">Имеется {n} объект.</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '      <unit id="2" name="foobar" type="res:plural" l:datatype="ruby" l:category="few">\n' +
+                '        <notes>\n' +
+                '          <note appliesTo="source">{"pluralForm":"few","pluralFormOther":"foobar"}</note>\n' +
+                '        </notes>\n' +
+                '        <segment>\n' +
+                '          <source>There are {n} objects.</source>\n' +
+                '          <target state="new">Есть {n} объекта.</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '      <unit id="3" name="foobar" type="res:plural" l:datatype="ruby" l:category="other">\n' +
+                '        <notes>\n' +
+                '          <note appliesTo="source">{"pluralForm":"other","pluralFormOther":"foobar"}</note>\n' +
+                '        </notes>\n' +
+                '        <segment>\n' +
+                '          <source>There are {n} objects.</source>\n' +
+                '          <target state="new">Всего {n} объектов.</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '</xliff>';
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testXliff20SerializeWithArrays: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        res = new ResourceArray({
+            sourceArray: ["Zero", "One", "Two"],
+            sourceLocale: "en-US",
+            targetArray: ["Zero", "Eins", "Zwei"],
+            targetLocale: "de-DE",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <group id="group_1" name="x-android-resource">\n' +
+                '      <unit id="1" name="foobar" type="res:array" l:datatype="x-android-resource" l:index="0">\n' +
+                '        <segment>\n' +
+                '          <source>Zero</source>\n' +
+                '          <target>Zero</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '      <unit id="2" name="foobar" type="res:array" l:datatype="x-android-resource" l:index="1">\n' +
+                '        <segment>\n' +
+                '          <source>One</source>\n' +
+                '          <target>Eins</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '      <unit id="3" name="foobar" type="res:array" l:datatype="x-android-resource" l:index="2">\n' +
+                '        <segment>\n' +
+                '          <source>Two</source>\n' +
+                '          <target>Zwei</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '</xliff>';
+        diff(actual, expected)
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliff20SerializeWithXMLEscaping: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf <b>asdf</b>",
+            sourceLocale: "en-US",
+            target: "Asdf 'quotes'",
+            targetLocale: "de-DE",
+            key: 'foobar "asdf"',
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        res = new ResourceString({
+            source: "baby &lt;b&gt;baby&lt;/b&gt;",
+            sourceLocale: "en-US",
+            target: "baby #(test)",
+            targetLocale: "de-DE",
+            key: "huzzah &quot;asdf&quot; #(test)",
+            pathName: "foo/bar/j.java",
+            project: "webapp",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        var actual = x.serialize();
+        var expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <group id="group_1" name="plaintext">\n' +
+                '      <unit id="1" name="foobar &quot;asdf&quot;" type="res:string" l:datatype="plaintext">\n' +
+                '        <segment>\n' +
+                '          <source>Asdf &lt;b&gt;asdf&lt;/b&gt;</source>\n' +
+                '          <target>Asdf \'quotes\'</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <group id="group_2" name="plaintext">\n' +
+                '      <unit id="2" name="huzzah &amp;quot;asdf&amp;quot; #(test)" type="res:string" l:datatype="plaintext">\n' +
+                '        <segment>\n' +
+                '          <source>baby &amp;lt;b&amp;gt;baby&amp;lt;/b&amp;gt;</source>\n' +   // double escaped!
+                '          <target>baby #(test)</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliff20SerializeWithXMLEscapingWithQuotes: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Here are \"double\" and 'single' quotes.",
+            sourceLocale: "en-US",
+            target: "Hier zijn \"dubbel\" en 'singel' quotaties.",
+            targetLocale: "nl-NL",
+            key: '"double" and \'single\'',
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        test.equal(x.serialize(),
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="nl-NL" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <group id="group_1" name="plaintext">\n' +
+                '      <unit id="1" name="&quot;double&quot; and &apos;single&apos;" type="res:string" l:datatype="plaintext">\n' +
+                '        <segment>\n' +
+                '          <source>Here are "double" and \'single\' quotes.</source>\n' +
+                '          <target>Hier zijn "dubbel" en \'singel\' quotaties.</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        test.done();
+    },
+
+    testXliff20SerializeWithEscapeCharsInResname: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Here are \\ndouble\\n quotes.",
+            sourceLocale: "en-US",
+            target: "Hier zijn \\ndubbel\\n quotaties.",
+            targetLocale: "nl-NL",
+            key: 'Double \\ndouble\\n.',
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        test.equal(x.serialize(),
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="nl-NL" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <group id="group_1" name="plaintext">\n' +
+                '      <unit id="1" name="Double \\ndouble\\n." type="res:string" l:datatype="plaintext">\n' +
+                '        <segment>\n' +
+                '          <source>Here are \\ndouble\\n quotes.</source>\n' +
+                '          <target>Hier zijn \\ndubbel\\n quotaties.</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        test.done();
+    },
+
+    testXliff20SerializeWithComments: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            target: "baby baby",
+            targetLocale: "nl-NL",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "androidapp",
+            comment: "A very nice string",
+            origin: "target"
+        });
+
+        x.addResource(res);
+
+        test.equal(x.serialize(),
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="nl-NL" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <group id="group_1" name="plaintext">\n' +
+                '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
+                '        <notes>\n' +
+                '          <note appliesTo="source">A very nice string</note>\n' +
+                '        </notes>\n' +
+                '        <segment>\n' +
+                '          <source>Asdf asdf</source>\n' +
+                '          <target>baby baby</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithSourceOnly: function(test) {
+        test.expect(21);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" \n' +
+                '  xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
+                '      <segment>\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:string" l:datatype="plaintext">\n' +
+                '      <segment>\n' +
+                '        <source>baby baby</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 2);
+
+        test.equal(reslist[0].getSource(), "Asdf asdf");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.ok(!reslist[0].getTarget());
+        test.equal(reslist[0].getTargetLocale(), "de-DE");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), "1");
+
+        test.equal(reslist[1].getSource(), "baby baby");
+        test.equal(reslist[1].getSourceLocale(), "en-US");
+        test.ok(!reslist[1].getTarget());
+        test.equal(reslist[1].getTargetLocale(), "de-DE");
+        test.equal(reslist[1].getKey(), "huzzah");
+        test.equal(reslist[1].getPath(), "foo/bar/j.java");
+        test.equal(reslist[1].getProject(), "webapp");
+        test.equal(reslist[1].resType, "string");
+        test.equal(reslist[1].getId(), "2");
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithSourceAndTarget: function(test) {
+        test.expect(21);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '        <target>foobarfoo</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>baby baby</source>\n' +
+                '        <target>bebe bebe</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        // console.log("x is " + JSON.stringify(x, undefined, 4));
+        var reslist = x.getResources();
+        // console.log("x is now " + JSON.stringify(x, undefined, 4));
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 2);
+
+        test.equal(reslist[0].getSource(), "Asdf asdf");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), "1");
+        test.equal(reslist[0].getTarget(), "foobarfoo");
+        test.equal(reslist[0].getTargetLocale(), "de-DE");
+
+        test.equal(reslist[1].getSource(), "baby baby");
+        test.equal(reslist[1].getSourceLocale(), "en-US");
+        test.equal(reslist[1].getKey(), "huzzah");
+        test.equal(reslist[1].getPath(), "foo/bar/j.java");
+        test.equal(reslist[1].getProject(), "webapp");
+        test.equal(reslist[1].resType, "string");
+        test.equal(reslist[1].getId(), "2");
+        test.equal(reslist[1].getTarget(), "bebe bebe");
+        test.equal(reslist[1].getTargetLocale(), "de-DE");
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithXMLUnescaping: function(test) {
+        test.expect(19);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" xmlns:l="http://ilib-js.com/loctool" srcLang="en-US">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>Asdf &lt;b&gt;asdf&lt;/b&gt;</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>baby &amp;lt;b&amp;gt;baby&amp;lt;/b&amp;gt;</source>\n' +   // double escaped!
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 2);
+
+        test.equal(reslist[0].getSource(), "Asdf <b>asdf</b>");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), "1");
+        test.ok(!reslist[0].getTarget());
+
+        test.equal(reslist[1].getSource(), "baby &lt;b&gt;baby&lt;/b&gt;");
+        test.equal(reslist[1].getSourceLocale(), "en-US");
+        test.equal(reslist[1].getKey(), "huzzah");
+        test.equal(reslist[1].getPath(), "foo/bar/j.java");
+        test.equal(reslist[1].getProject(), "webapp");
+        test.equal(reslist[1].resType, "string");
+        test.equal(reslist[1].getId(), "2");
+        test.ok(!reslist[1].getTarget());
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithEscapedNewLines: function(test) {
+        test.expect(17);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="en-CA" \n' +
+                '  xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>a\\nb</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>e\\nh</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 2);
+
+        test.equal(reslist[0].getSource(), "a\\nb");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), "1");
+
+        test.equal(reslist[1].getSource(), "e\\nh");
+        test.equal(reslist[1].getSourceLocale(), "en-US");
+        test.equal(reslist[1].getKey(), "huzzah");
+        test.equal(reslist[1].getPath(), "foo/bar/j.java");
+        test.equal(reslist[1].getProject(), "webapp");
+        test.equal(reslist[1].resType, "string");
+        test.equal(reslist[1].getId(), "2");
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithEscapedNewLinesInResname: function(test) {
+        test.expect(17);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="en-CA" \n' +
+                '  xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar\\nbar\\t" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>a\\nb</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah\\n\\na plague on both your houses" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>e\\nh</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 2);
+
+        test.equal(reslist[0].getSource(), "a\\nb");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar\\nbar\\t");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), "1");
+
+        test.equal(reslist[1].getSource(), "e\\nh");
+        test.equal(reslist[1].getSourceLocale(), "en-US");
+        test.equal(reslist[1].getKey(), "huzzah\\n\\na plague on both your houses");
+        test.equal(reslist[1].getPath(), "foo/bar/j.java");
+        test.equal(reslist[1].getProject(), "webapp");
+        test.equal(reslist[1].resType, "string");
+        test.equal(reslist[1].getId(), "2");
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithPlurals: function(test) {
+        test.expect(10);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" xmlns:l="http://ilib-js.com/loctool" srcLang="en-US">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="one">\n' +
+                '      <segment>\n' +
+                '        <source>There is 1 object.</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '    <unit id="2" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="other">\n' +
+                '      <segment>\n' +
+                '        <source>There are {n} objects.</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        // console.log("x is " + JSON.stringify(x, undefined, 4));
+
+        var reslist = x.getResources();
+
+        // console.log("after get resources x is " + JSON.stringify(x, undefined, 4));
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.deepEqual(reslist[0].getSourcePlurals(), {
+            one: "There is 1 object.",
+            other: "There are {n} objects."
+        });
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "plural");
+        test.equal(reslist[0].getId(), "1");
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithPluralsTranslated: function(test) {
+        test.expect(13);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="es-US" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="one">\n' +
+                '      <segment>\n' +
+                '        <source>There is 1 object.</source>\n' +
+                '        <target>Hay 1 objeto.</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '    <unit id="2" name="foobar" type="res:plural" l:datatype="x-android-resource" l:category="other">\n' +
+                '      <segment>\n' +
+                '        <source>There are {n} objects.</source>\n' +
+                '        <target>Hay {n} objetos.</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        // console.log("x is " + JSON.stringify(x, undefined, 4));
+
+        var reslist = x.getResources();
+
+        // console.log("after get resources x is " + JSON.stringify(x, undefined, 4));
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.deepEqual(reslist[0].getSourcePlurals(), {
+            one: "There is 1 object.",
+            other: "There are {n} objects."
+        });
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "plural");
+        test.equal(reslist[0].getId(), "1");
+        test.equal(reslist[0].getOrigin(), "source");
+
+        test.deepEqual(reslist[0].getTargetPlurals(), {
+            one: "Hay 1 objeto.",
+            other: "Hay {n} objetos."
+        });
+        test.equal(reslist[0].getTargetLocale(), "es-US");
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithArrays: function(test) {
+        test.expect(10);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar" type="res:array" l:datatype="x-android-resource" l:index="0">\n' +
+                '      <segment>\n' +
+                '        <source>Zero</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '    <unit id="2" name="foobar" type="res:array" l:datatype="x-android-resource" l:index="1">\n' +
+                '      <segment>\n' +
+                '        <source>One</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '    <unit id="3" name="foobar" type="res:array" l:datatype="x-android-resource" l:index="2">\n' +
+                '      <segment>\n' +
+                '        <source>Two</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.deepEqual(reslist[0].getSourceArray(), ["Zero", "One", "Two"]);
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "array");
+        test.ok(!reslist[0].getTargetArray());
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithArraysTranslated: function(test) {
+        test.expect(12);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar" type="res:array" l:datatype="x-android-resource" l:index="0">\n' +
+                '      <segment>\n' +
+                '        <source>Zero</source>\n' +
+                '        <target>Zero</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '    <unit id="2" name="foobar" type="res:array" l:datatype="x-android-resource" l:index="1">\n' +
+                '      <segment>\n' +
+                '        <source>One</source>\n' +
+                '        <target>Eins</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '    <unit id="3" name="foobar" type="res:array" l:datatype="x-android-resource" l:index="2">\n' +
+                '      <segment>\n' +
+                '        <source>Two</source>\n' +
+                '        <target>Zwei</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.deepEqual(reslist[0].getSourceArray(), ["Zero", "One", "Two"]);
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "array");
+        test.equal(reslist[0].getOrigin(), "source");
+        test.deepEqual(reslist[0].getTargetArray(), ["Zero", "Eins", "Zwei"]);
+        test.equal(reslist[0].getTargetLocale(), "de-DE");
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithArraysAndTranslations: function(test) {
+        test.expect(20);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="es-US" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="res/values/arrays.xml" l:project="androidapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:array" l:datatype="x-android-resource" l:index="0">\n' +
+                '      <segment>\n' +
+                '        <source>This is element 0</source>\n' +
+                '        <target>Este es 0</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '    <unit id="3" name="huzzah" type="res:array" l:datatype="x-android-resource" l:index="1">\n' +
+                '      <segment>\n' +
+                '        <source>This is element 1</source>\n' +
+                '        <target>Este es 1</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '    <unit id="4" name="huzzah" type="res:array" l:datatype="x-android-resource" l:index="2">\n' +
+                '      <segment>\n' +
+                '        <source>This is element 2</source>\n' +
+                '        <target>Este es 2</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '    <unit id="5" name="huzzah" type="res:array" l:datatype="x-android-resource" l:index="3">\n' +
+                '      <segment>\n' +
+                '        <source>This is element 3</source>\n' +
+                '        <target>Este es 3</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getTargetLocale(), "es-US");
+        test.equal(reslist[0].getKey(), "huzzah");
+        test.equal(reslist[0].getPath(), "res/values/arrays.xml");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "array");
+        test.equal(reslist[0].getOrigin(), "source");
+
+        var items = reslist[0].getSourceArray();
+
+        test.equal(items.length, 4);
+        test.equal(items[0], "This is element 0");
+        test.equal(items[1], "This is element 1");
+        test.equal(items[2], "This is element 2");
+        test.equal(items[3], "This is element 3");
+
+        items = reslist[0].getTargetArray();
+
+        test.equal(items.length, 4);
+        test.equal(items[0], "Este es 0");
+        test.equal(items[1], "Este es 1");
+        test.equal(items[2], "Este es 2");
+        test.equal(items[3], "Este es 3");
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithArraysAndTranslationsPartial: function(test) {
+        test.expect(20);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="es-US" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="res/values/arrays.xml" l:project="androidapp">\n' +
+                '    <unit id="5" name="huzzah" type="res:array" l:datatype="x-android-resource" l:index="3">\n' +
+                '      <segment>\n' +
+                '        <source>This is element 3</source>\n' +
+                '        <target>Este es 3</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getTargetLocale(), "es-US");
+        test.equal(reslist[0].getKey(), "huzzah");
+        test.equal(reslist[0].getPath(), "res/values/arrays.xml");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "array");
+        test.equal(reslist[0].getOrigin(), "source");
+
+        var items = reslist[0].getSourceArray();
+
+        test.equal(items.length, 4);
+        test.equal(items[0], null);
+        test.equal(items[1], null);
+        test.equal(items[2], null);
+        test.equal(items[3], "This is element 3");
+
+        items = reslist[0].getTargetArray();
+
+        test.equal(items.length, 4);
+        test.equal(items[0], null);
+        test.equal(items[1], null);
+        test.equal(items[2], null);
+        test.equal(items[3], "Este es 3");
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithComments: function(test) {
+        test.expect(18);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" xmlns:l="http://ilib-js.com/loctool" srcLang="en-US">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar" type="res:string">\n' +
+                '      <notes>\n' +
+                '        <note appliesTo="source">A very nice string</note>\n' +
+                '      </notes>\n' +
+                '      <segment>\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:string">\n' +
+                '      <notes>\n' +
+                '        <note appliesTo="source">Totally awesome.</note>\n' +
+                '      </notes>\n' +
+                '      <segment>\n' +
+                '        <source>baby baby</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist[0].getSource(), "Asdf asdf");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getComment(), "A very nice string");
+        test.equal(reslist[0].getId(), "1");
+
+        test.equal(reslist[1].getSource(), "baby baby");
+        test.equal(reslist[1].getSourceLocale(), "en-US");
+        test.equal(reslist[1].getKey(), "huzzah");
+        test.equal(reslist[1].getPath(), "foo/bar/j.java");
+        test.equal(reslist[1].getProject(), "webapp");
+        test.equal(reslist[1].resType, "string");
+        test.equal(reslist[1].getComment(), "Totally awesome.");
+        test.equal(reslist[1].getId(), "2");
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithContext: function(test) {
+        test.expect(19);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar" type="res:string" l:context="na na na">\n' +
+                '      <segment>\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:string" l:context="asdf">\n' +
+                '      <segment>\n' +
+                '        <source>baby baby</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 2);
+
+        test.equal(reslist[0].getSource(), "Asdf asdf");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), "1");
+        test.equal(reslist[0].getContext(), "na na na");
+
+        test.equal(reslist[1].getSource(), "baby baby");
+        test.equal(reslist[1].getSourceLocale(), "en-US");
+        test.equal(reslist[1].getKey(), "huzzah");
+        test.equal(reslist[1].getPath(), "foo/bar/j.java");
+        test.equal(reslist[1].getProject(), "webapp");
+        test.equal(reslist[1].resType, "string");
+        test.equal(reslist[1].getId(), "2");
+        test.equal(reslist[1].getContext(), "asdf");
+
+        test.done();
+    },
+
+    testXliff20DeserializeRealFile: function(test) {
+        test.expect(3);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        var fs = require("fs");
+
+        var str = fs.readFileSync("testfiles/test4.xliff", "utf-8");
+
+        x.deserialize(str);
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 4);
+
+        test.done();
+    },
+
+    testXliff20DeserializeEmptySource: function(test) {
+        test.expect(12);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="de-DE" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar" type="res:string" l:context="na na na">\n' +
+                '      <segment>\n' +
+                '        <source></source>\n' +
+                '        <target>Baby Baby</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>baby baby</source>\n' +
+                '        <target>bebe bebe</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getSource(), "baby baby");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "huzzah");
+        test.equal(reslist[0].getPath(), "foo/bar/j.java");
+        test.equal(reslist[0].getProject(), "webapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), "2");
+
+        test.equal(reslist[0].getTarget(), "bebe bebe");
+        test.equal(reslist[0].getTargetLocale(), "de-DE");
+
+        test.done();
+    },
+
+    testXliff20DeserializeEmptyTarget: function(test) {
+        test.expect(23);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>baby baby</source>\n' +
+                '        <target></target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 2);
+
+        test.equal(reslist[0].getSource(), "Asdf asdf");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.ok(!reslist[0].getTarget());
+        test.equal(reslist[0].getTargetLocale(), "fr-FR");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), "1");
+        test.equal(reslist[0].getOrigin(), "source");
+
+        test.equal(reslist[1].getSource(), "baby baby");
+        test.equal(reslist[1].getSourceLocale(), "en-US");
+        test.ok(!reslist[0].getTarget());
+        test.equal(reslist[0].getTargetLocale(), "fr-FR");
+        test.equal(reslist[1].getKey(), "huzzah");
+        test.equal(reslist[1].getPath(), "foo/bar/j.java");
+        test.equal(reslist[1].getProject(), "webapp");
+        test.equal(reslist[1].resType, "string");
+        test.equal(reslist[1].getId(), "2");
+        test.equal(reslist[1].getOrigin(), "source");
+
+        test.done();
+    },
+
+    testXliff20DeserializeEmptyTargetNoTargetLocale: function(test) {
+        test.expect(23);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" xmlns:l="http://ilib-js.com/loctool" srcLang="en-US">\n' +
+                '  <file original="foo/bar/asdf.java" l:project="androidapp">\n' +
+                '    <unit id="1" name="foobar" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>Asdf asdf</source>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:string">\n' +
+                '      <segment>\n' +
+                '        <source>baby baby</source>\n' +
+                '        <target></target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 2);
+
+        test.equal(reslist[0].getSource(), "Asdf asdf");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.ok(!reslist[0].getTarget());
+        test.ok(!reslist[0].getTargetLocale());
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "androidapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), "1");
+        test.equal(reslist[0].getOrigin(), "source");
+
+        test.equal(reslist[1].getSource(), "baby baby");
+        test.equal(reslist[1].getSourceLocale(), "en-US");
+        test.ok(!reslist[0].getTarget());
+        test.ok(!reslist[0].getTargetLocale());
+        test.equal(reslist[1].getKey(), "huzzah");
+        test.equal(reslist[1].getPath(), "foo/bar/j.java");
+        test.equal(reslist[1].getProject(), "webapp");
+        test.equal(reslist[1].resType, "string");
+        test.equal(reslist[1].getId(), "2");
+        test.equal(reslist[1].getOrigin(), "source");
+
+        test.done();
+    },
+
+    testXliff20DeserializeWithMultipleSegments: function(test) {
+        test.expect(12);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="foo/bar/j.java" l:project="webapp">\n' +
+                '    <unit id="2" name="huzzah" type="res:string">\n' +
+                '      <segment id="1">\n' +
+                '        <source>seg1 </source>\n' +
+                '        <target>This is segment 1. </target>\n' +
+                '      </segment>\n' +
+                '      <segment id="2">\n' +
+                '        <source>seg2 </source>\n' +
+                '        <target>This is segment 2. </target>\n' +
+                '      </segment>\n' +
+                '      <segment id="3">\n' +
+                '        <source>seg3</source>\n' +
+                '        <target>This is segment 3.</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getSource(), "seg1 seg2 seg3");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "huzzah");
+        test.equal(reslist[0].getPath(), "foo/bar/j.java");
+        test.equal(reslist[0].getProject(), "webapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), "2");
+
+        test.equal(reslist[0].getTarget(), "This is segment 1. This is segment 2. This is segment 3.");
+        test.equal(reslist[0].getTargetLocale(), "fr-FR");
+
+        test.done();
+    },
+
+    testXliff20DeserializePreserveSourceWhitespace: function(test) {
+        test.expect(9);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="es-US" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="UI/AddAnotherButtonView.m" l:project="iosapp">\n' +
+                '    <unit id="196" name="      Add Another" type="res:string" l:datatype="x-objective-c">\n' +
+                '      <segment>\n' +
+                '        <source>      Add Another</source>\n' +
+                '        <target>Añadir Otro</target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getSource(), "      Add Another");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "      Add Another");
+        test.equal(reslist[0].getPath(), "UI/AddAnotherButtonView.m");
+        test.equal(reslist[0].getProject(), "iosapp");
+        test.equal(reslist[0].resType, "string");
+
+        test.done();
+    },
+
+    testXliff20DeserializePreserveTargetWhitespace: function(test) {
+        test.expect(9);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="es-US" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="UI/AddAnotherButtonView.m" l:project="iosapp">\n' +
+                '    <unit id="196" name="      Add Another" type="res:string" l:datatype="x-objective-c">\n' +
+                '      <segment>\n' +
+                '        <source>      Add Another</source>\n' +
+                '        <target> Añadir    Otro  </target>\n' +
+                '      </segment>\n' +
+                '    </unit>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getTarget(), " Añadir    Otro  ");
+        test.equal(reslist[0].getTargetLocale(), "es-US");
+        test.equal(reslist[0].getKey(), "      Add Another");
+        test.equal(reslist[0].getPath(), "UI/AddAnotherButtonView.m");
+        test.equal(reslist[0].getProject(), "iosapp");
+        test.equal(reslist[0].resType, "string");
+
+        test.done();
+    },
+
+    testXliff20AddTranslationUnit: function(test) {
+        test.expect(10);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getSource(), "a");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "/a/b/asdf.js");
+        test.equal(reslist[0].getProject(), "iosapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), 2334);
+
+        test.done();
+    },
+
+    testXliff20AddTranslationUnitMergeResources: function(test) {
+        test.expect(12);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "b",
+            "targetLocale": "fr-FR",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getSource(), "a");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getTarget(), "b");
+        test.equal(reslist[0].getTargetLocale(), "fr-FR");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "/a/b/asdf.js");
+        test.equal(reslist[0].getProject(), "iosapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].getId(), 2334);
+
+        test.done();
+    },
+
+    testXliff20AddTranslationUnitAddMultipleUnits: function(test) {
+        test.expect(3);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "bababa",
+            "sourceLocale": "en-US",
+            "target": "ababab",
+            "targetLocale": "fr-FR",
+            "key": "asdf",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2333,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "b",
+            "targetLocale": "fr-FR",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        var units = x.getTranslationUnits();
+
+        test.ok(units);
+
+        test.equal(units.length, 2);
+
+        test.done();
+    },
+
+    testXliff20AddTranslationUnitReplacePreviousUnit: function(test) {
+        test.expect(3);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "b",
+            "targetLocale": "fr-FR",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "ab",
+            "sourceLocale": "en-US",
+            "target": "ba",
+            "targetLocale": "fr-FR",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a new comment"
+        }));
+
+        var units = x.getTranslationUnits();
+
+        test.ok(units);
+
+        // should have merged them into 1 unit because the signature was the same
+        test.equal(units.length, 1);
+
+        test.done();
+    },
+
+    testXliff20AddTranslationUnitRightContents: function(test) {
+        test.expect(15);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "b",
+            "targetLocale": "fr-FR",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "ab",
+            "sourceLocale": "en-US",
+            "target": "ba",
+            "targetLocale": "fr-FR",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a new comment"
+        }));
+
+        var units = x.getTranslationUnits();
+
+        test.ok(units);
+
+        test.equal(units.length, 1);
+
+        test.equal(units[0].source, "ab");
+        test.equal(units[0].sourceLocale, "en-US");
+        test.equal(units[0].target, "ba");
+        test.equal(units[0].targetLocale, "fr-FR");
+        test.equal(units[0].key, "foobar");
+        test.equal(units[0].file, "/a/b/asdf.js");
+        test.equal(units[0].project, "iosapp");
+        test.equal(units[0].id, 2334);
+        test.equal(units[0].resType, "string");
+        test.equal(units[0].origin, "source");
+        test.equal(units[0].context, "asdfasdf");
+        test.equal(units[0].comment, "this is a new comment");
+
+        test.done();
+    },
+
+    testXliff20AddTranslationUnitRightResourceTypesRegularString: function(test) {
+        test.expect(4);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "b",
+            "targetLocale": "fr-FR",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType": "string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment",
+            "datatype": "javascript"
+        }));
+
+        var resources = x.getResources();
+
+        test.ok(resources);
+
+        test.equal(resources.length, 1);
+
+        test.ok(resources[0] instanceof ResourceString);
+
+        test.done();
+    },
+
+    testXliff20AddTranslationUnitRightResourceTypesContextString: function(test) {
+        test.expect(5);
+
+        ResourceFactory.registerDataType("x-android-resource", "string", ContextResourceString);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "ba",
+            "targetLocale": "fr-FR",
+            "key": "foobar",
+            "file": "/a/b/asdf.xml",
+            "project": "androidapp",
+            "id": 2334,
+            "resType":"string",
+            "comment": "this is a comment",
+            "datatype": "x-android-resource",
+            "flavor": "chocolate"
+        }));
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "baa",
+            "targetLocale": "fr-FR",
+            "key": "foobar",
+            "file": "/a/b-x/asdf.xml",
+            "project": "androidapp",
+            "id": 2334,
+            "resType": "string",
+            "context": "x",
+            "comment": "this is a new comment",
+            "datatype": "x-android-resource",
+            "flavor": "chocolate"
+        }));
+
+        var resources = x.getResources();
+
+        test.ok(resources);
+
+        test.equal(resources.length, 2);
+
+        test.ok(resources[0] instanceof ContextResourceString);
+        test.ok(resources[1] instanceof ContextResourceString);
+
+        test.done();
+    },
+
+    testXliff20AddTranslationUnitReplaceSourceOnlyUnit: function(test) {
+        test.expect(3);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType": "string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "b",
+            "targetLocale": "fr-FR",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        var units = x.getTranslationUnits();
+
+        test.ok(units);
+
+        // should have merged them into 1 unit because the signature was the same
+        test.equal(units.length, 1);
+
+        test.done();
+    },
+
+    testXliff20AddTranslationUnitDifferentPathsRightTypes: function(test) {
+        test.expect(5);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        ResourceFactory.registerDataType("x-xib", "string", IosLayoutResourceString);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "foo",
+            "targetLocale": "de-DE",
+            "key": "foobar",
+            "file": "a/b/asdf.xib",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "origin": "target",
+            "comment": "this is a comment",
+            "datatype": "x-xib"
+        }));
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "foo",
+            "targetLocale": "de-DE",
+            "key": "foobar",
+            "file": "a/b/asdf~ipad.xib",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "origin": "target",
+            "comment": "this is a comment",
+            "datatype": "x-xib"
+        }));
+
+        var resources = x.getResources();
+
+        test.ok(resources);
+
+        test.equal(resources.length, 2);
+
+        test.ok(resources[0] instanceof IosLayoutResourceString);
+        test.ok(resources[1] instanceof IosLayoutResourceString);
+
+        test.done();
+    },
+
+    testXliff20AddTranslationUnitDifferentPaths: function(test) {
+        test.expect(23);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        ResourceFactory.registerDataType("x-xib", "string", IosLayoutResourceString);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "foo",
+            "targetLocale": "de-DE",
+            "key": "foobar",
+            "file": "a/b/asdf.xib",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "comment": "this is a comment",
+            "datatype": "x-xib"
+        }));
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "foo",
+            "targetLocale": "de-DE",
+            "key": "foobar",
+            "file": "a/b/asdf~ipad.xib",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "comment": "this is a comment",
+            "datatype": "x-xib"
+        }));
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 2);
+
+        test.equal(reslist[0].getSource(), "a");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getTarget(), "foo");
+        test.equal(reslist[0].getTargetLocale(), "de-DE");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "a/b/asdf.xib");
+        test.equal(reslist[0].getProject(), "iosapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].datatype, "x-xib");
+        test.equal(reslist[0].getId(), 2334);
+
+        test.equal(reslist[1].getSource(), "a");
+        test.equal(reslist[1].getSourceLocale(), "en-US");
+        test.equal(reslist[1].getTarget(), "foo");
+        test.equal(reslist[1].getTargetLocale(), "de-DE");
+        test.equal(reslist[1].getKey(), "foobar");
+        test.equal(reslist[1].getPath(), "a/b/asdf~ipad.xib");
+        test.equal(reslist[1].getProject(), "iosapp");
+        test.equal(reslist[1].resType, "string");
+        test.equal(reslist[1].datatype, "x-xib");
+        test.equal(reslist[1].getId(), 2334);
+
+        test.done();
+    },
+
+    testXliff20SerializeWithTranslationUnits: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "bababa",
+            "sourceLocale": "en-US",
+            "target": "ababab",
+            "targetLocale": "fr-FR",
+            "key": "asdf",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2333,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "a",
+            "sourceLocale": "en-US",
+            "target": "b",
+            "targetLocale": "fr-FR",
+            "key": "foobar",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        var expected =
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="2.0" srcLang="en-US" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">\n' +
+                '  <file original="/a/b/asdf.js" l:project="iosapp">\n' +
+                '    <group id="group_1" name="plaintext">\n' +
+                '      <unit id="2333" name="asdf" type="res:string" l:context="asdfasdf">\n' +
+                '        <notes>\n' +
+                '          <note appliesTo="source">this is a comment</note>\n' +
+                '        </notes>\n' +
+                '        <segment>\n' +
+                '          <source>bababa</source>\n' +
+                '          <target>ababab</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '      <unit id="2334" name="foobar" type="res:string" l:context="asdfasdf">\n' +
+                '        <notes>\n' +
+                '          <note appliesTo="source">this is a comment</note>\n' +
+                '        </notes>\n' +
+                '        <segment>\n' +
+                '          <source>a</source>\n' +
+                '          <target>b</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '</xliff>';
+
+        diff(x.serialize(), expected);
+        test.equal(x.serialize(), expected);
+
+        test.done();
+    },
+
+    testXliff20SerializeWithTranslationUnitsDifferentLocales: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({version: "2.0"});
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "bababa",
+            "sourceLocale": "en-US",
+            "target": "ababab",
+            "targetLocale": "fr-FR",
+            "key": "asdf",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2333,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        try {
+            x.addTranslationUnit(new TranslationUnit({
+                "source": "a",
+                "sourceLocale": "en-US",
+                "target": "b",
+                "targetLocale": "de-DE",
+                "key": "foobar",
+                "file": "/a/b/asdf.js",
+                "project": "iosapp",
+                "id": 2334,
+                "resType":"string",
+                "origin": "source",
+                "context": "asdfasdf",
+                "comment": "this is a comment"
+            }));
+        } catch (e) {
+            // cannot add new units with a different source/language combo
+            test.ok(e);
+        }
+
+        test.done();
+    },
+
+    testXliff20AddResourcesWithInstances: function(test) {
+        test.expect(9);
+
+        var x = new Xliff({
+            version: "2.0",
+            allowDups: true
+        });
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp"
+        });
+
+        var res2 = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp",
+            comment: "special translators note"
+        });
+        res.addInstance(res2);
+
+        x.addResource(res);
+
+        var reslist = x.getResources({
+            reskey: "foobar"
+        });
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+        test.equal(reslist[0].getSource(), "Asdf asdf");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "webapp");
+        test.ok(!reslist[0].getComment());
+
+        test.done();
+    },
+
+    testXliff20AddMultipleResourcesAddInstances: function(test) {
+        test.expect(17);
+
+        var x = new Xliff({
+            version: "2.0",
+            allowDups: true
+        });
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        // this one has the same source, locale, key, and file
+        // so it should create an instance of the first one
+        res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            comment: "blah blah blah",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        var reslist = x.getResources({
+            reskey: "foobar"
+        });
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+        test.equal(reslist[0].getSource(), "Asdf asdf");
+        test.equal(reslist[0].getSourceLocale(), "en-US");
+        test.equal(reslist[0].getKey(), "foobar");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "webapp");
+        test.ok(!reslist[0].getComment());
+
+        var instances = reslist[0].getInstances();
+        test.ok(instances);
+        test.equal(instances.length, 1);
+
+        test.equal(instances[0].getSource(), "Asdf asdf");
+        test.equal(instances[0].getSourceLocale(), "en-US");
+        test.equal(instances[0].getKey(), "foobar");
+        test.equal(instances[0].getPath(), "foo/bar/asdf.java");
+        test.equal(instances[0].getProject(), "webapp");
+        test.equal(instances[0].getComment(), "blah blah blah");
+
+        test.done();
+    },
+
+    testXliff20SerializeWithResourcesWithInstancesWithNoTarget: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({
+            version: "2.0",
+            allowDups: true
+        });
+        test.ok(x);
+
+        var res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        // this one has the same source, locale, key, and file
+        // so it should create an instance of the first one
+        res = new ResourceString({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            key: "foobar",
+            pathName: "foo/bar/asdf.java",
+            comment: "blah blah blah",
+            project: "webapp"
+        });
+
+        x.addResource(res);
+
+        var expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="2.0" srcLang="en-US" xmlns:l="http://ilib-js.com/loctool">\n' +
+            '  <file original="foo/bar/asdf.java" l:project="webapp">\n' +
+            '    <group id="group_1" name="plaintext">\n' +
+            '      <unit id="1" name="foobar" type="res:string" l:datatype="plaintext">\n' +
+            '        <segment>\n' +
+            '          <source>Asdf asdf</source>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '      <unit id="2" name="foobar" type="res:string" l:datatype="plaintext">\n' +
+            '        <notes>\n' +
+            '          <note appliesTo="source">blah blah blah</note>\n' +
+            '        </notes>\n' +
+            '        <segment>\n' +
+            '          <source>Asdf asdf</source>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '    </group>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        var actual = x.serialize();
+        diff(actual, expected);
+
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testXliff20SerializeWithTranslationUnitsWithInstances: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({
+            version: "2.0",
+            allowDups: true
+        });
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "bababa",
+            "sourceLocale": "en-US",
+            "target": "ababab",
+            "targetLocale": "fr-FR",
+            "key": "asdf",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2333,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment"
+        }));
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "bababa",
+            "sourceLocale": "en-US",
+            "target": "ababab",
+            "targetLocale": "fr-FR",
+            "key": "asdf",
+            "file": "/a/b/asdf.js",
+            "project": "iosapp",
+            "id": 2334,
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a different comment"
+        }));
+
+        var expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="2.0" srcLang="en-US" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">\n' +
+            '  <file original="/a/b/asdf.js" l:project="iosapp">\n' +
+            '    <group id="group_1" name="plaintext">\n' +
+            '      <unit id="2333" name="asdf" type="res:string" l:context="asdfasdf">\n' +
+            '        <notes>\n' +
+            '          <note appliesTo="source">this is a comment</note>\n' +
+            '        </notes>\n' +
+            '        <segment>\n' +
+            '          <source>bababa</source>\n' +
+            '          <target>ababab</target>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '      <unit id="2334" name="asdf" type="res:string" l:context="asdfasdf">\n' +
+            '        <notes>\n' +
+            '          <note appliesTo="source">this is a different comment</note>\n' +
+            '        </notes>\n' +
+            '        <segment>\n' +
+            '          <source>bababa</source>\n' +
+            '          <target>ababab</target>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '    </group>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        var actual = x.serialize();
+        diff(actual, expected);
+
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testXliff20SerializeWithTranslationUnitsWithTypes: function(test) {
+        test.expect(2);
+
+        var x = new Xliff({
+            version: "2.0",
+            allowDups: true
+        });
+        test.ok(x);
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "bababa",
+            "sourceLocale": "en-US",
+            "target": "ababab",
+            "targetLocale": "fr-FR",
+            "key": "asdf",
+            "file": "/a/b/asdf.js",
+            "project": "webapp1",
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a comment",
+            "datatype": "javascript"
+        }));
+
+        x.addTranslationUnit(new TranslationUnit({
+            "source": "bababa",
+            "sourceLocale": "en-US",
+            "target": "ababab",
+            "targetLocale": "fr-FR",
+            "key": "asdf",
+            "file": "/a/b/asdf.js",
+            "project": "webapp1",
+            "resType":"string",
+            "origin": "source",
+            "context": "asdfasdf",
+            "comment": "this is a different comment",
+            "datatype": "x-json"
+        }));
+
+        var expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="2.0" srcLang="en-US" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">\n' +
+            '  <file original="/a/b/asdf.js" l:project="webapp1">\n' +
+            '    <group id="group_1" name="javascript">\n' +
+            '      <unit id="1" name="asdf" type="res:string" l:datatype="javascript" l:context="asdfasdf">\n' +
+            '        <notes>\n' +
+            '          <note appliesTo="source">this is a comment</note>\n' +
+            '        </notes>\n' +
+            '        <segment>\n' +
+            '          <source>bababa</source>\n' +
+            '          <target>ababab</target>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '    </group>\n' +
+            '    <group id="group_2" name="x-json">\n' +
+            '      <unit id="2" name="asdf" type="res:string" l:datatype="x-json" l:context="asdfasdf">\n' +
+            '        <notes>\n' +
+            '          <note appliesTo="source">this is a different comment</note>\n' +
+            '        </notes>\n' +
+            '        <segment>\n' +
+            '          <source>bababa</source>\n' +
+            '          <target>ababab</target>\n' +
+            '        </segment>\n' +
+            '      </unit>\n' +
+            '    </group>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+
+        var actual = x.serialize();
+        diff(actual, expected);
+
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testXliff20DeserializeCreateInstances: function(test) {
+        test.expect(21);
+
+        var x = new Xliff({
+            version: "2.0",
+            allowDups: true
+        });
+        test.ok(x);
+
+        x.deserialize(
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="2.0" srcLang="en-US" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">\n' +
+            '  <file original="/a/b/asdf.js" l:project="iosapp">\n' +
+            '    <unit id="2333" name="asdf" type="res:string" l:context="asdfasdf">\n' +
+            '      <notes>\n' +
+            '        <note appliesTo="source">this is a comment</note>\n' +
+            '      </notes>\n' +
+            '      <segment>\n' +
+            '        <source>bababa</source>\n' +
+            '        <target>ababab</target>\n' +
+            '      </segment>\n' +
+            '    </unit>\n' +
+            '    <unit id="2334" name="asdf" type="res:string" l:context="asdfasdf">\n' +
+            '      <notes>\n' +
+            '        <note appliesTo="source">this is a different comment</note>\n' +
+            '      </notes>\n' +
+            '      <segment>\n' +
+            '        <source>bababa</source>\n' +
+            '        <target>ababab</target>\n' +
+            '      </segment>\n' +
+            '    </unit>\n' +
+            '  </file>\n' +
+            '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist.length, 1);
+
+        test.equal(reslist[0].getTarget(), "ababab");
+        test.equal(reslist[0].getTargetLocale(), "fr-FR");
+        test.equal(reslist[0].getKey(), "asdf");
+        test.equal(reslist[0].getPath(), "/a/b/asdf.js");
+        test.equal(reslist[0].getProject(), "iosapp");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].context, "asdfasdf");
+        test.equal(reslist[0].comment, "this is a comment");
+
+        var instances = reslist[0].getInstances();
+        test.ok(instances);
+        test.equal(instances.length, 1);
+
+        test.equal(instances[0].getTarget(), "ababab");
+        test.equal(instances[0].getTargetLocale(), "fr-FR");
+        test.equal(instances[0].getKey(), "asdf");
+        test.equal(instances[0].getPath(), "/a/b/asdf.js");
+        test.equal(instances[0].getProject(), "iosapp");
+        test.equal(instances[0].resType, "string");
+        test.equal(instances[0].context, "asdfasdf");
+        test.equal(instances[0].comment, "this is a different comment");
+
+        test.done();
+    },
+
+    testXliff20DeserializeLGStyleXliff: function(test) {
+        test.expect(24);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-KR" trgLang="ko-KR">\n' +
+                '  <file id="f1" original="foo/bar/asdf.java" >\n' +
+                '    <group id="g1" name="javascript">\n' +
+                '      <unit id="1">\n' +
+                '        <segment>\n' +
+                '          <source>Closed Caption Settings</source>\n' +
+                '          <target>자막 설정</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '      <unit id="2">\n' +
+                '        <segment>\n' +
+                '          <source>Low</source>\n' +
+                '          <target>낮음</target>\n' +
+                '        </segment>\n' +
+                '      </unit>\n' +
+                '    </group>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        var reslist = x.getResources();
+
+        test.ok(reslist);
+
+        test.equal(reslist[0].getSource(), "Closed Caption Settings");
+        test.equal(reslist[0].getSourceLocale(), "en-KR");
+        test.equal(reslist[0].getTarget(), "자막 설정");
+        test.equal(reslist[0].getTargetLocale(), "ko-KR");
+        test.equal(reslist[0].getKey(), "Closed Caption Settings");
+        test.equal(reslist[0].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[0].getProject(), "foo/bar/asdf.java");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].datatype, "javascript");
+        test.ok(!reslist[0].getComment());
+        test.equal(reslist[0].getId(), "1");
+
+        test.equal(reslist[1].getSource(), "Low");
+        test.equal(reslist[1].getSourceLocale(), "en-KR");
+        test.equal(reslist[1].getTarget(), "낮음");
+        test.equal(reslist[1].getTargetLocale(), "ko-KR");
+        test.equal(reslist[1].getKey(), "Low");
+        test.equal(reslist[1].getPath(), "foo/bar/asdf.java");
+        test.equal(reslist[1].getProject(), "foo/bar/asdf.java");
+        test.equal(reslist[1].resType, "string");
+        test.equal(reslist[1].datatype, "javascript");
+        test.ok(!reslist[1].getComment());
+        test.equal(reslist[1].getId(), "2");
+
+        test.done();
+    },
+
+    testXliff20DeserializeRealLGFile: function(test) {
+        test.expect(37);
+
+        var x = new Xliff();
+        test.ok(x);
+
+        var fs = require("fs");
+
+        var str = fs.readFileSync("testfiles/test5.xliff", "utf-8");
+
+        x.deserialize(str);
+
+        var reslist = x.getResources();
+        test.ok(reslist);
+        test.equal(reslist.length, 7);
+
+        test.equal(reslist[0].getSource(), "Closed Caption Settings");
+        test.equal(reslist[0].getSourceLocale(), "en-KR");
+        test.equal(reslist[0].getTarget(), "자막 설정");
+        test.equal(reslist[0].getTargetLocale(), "ko-KR");
+        test.equal(reslist[0].getKey(), "Closed Caption Settings");
+        test.equal(reslist[0].getPath(), "settings");
+        test.equal(reslist[0].getProject(), "settings");
+        test.equal(reslist[0].resType, "string");
+        test.equal(reslist[0].datatype, "javascript");
+        test.ok(!reslist[0].getComment());
+        test.equal(reslist[0].getId(), "settings_1");
+
+        test.equal(reslist[3].getSource(), "Low");
+        test.equal(reslist[3].getSourceLocale(), "en-KR");
+        test.equal(reslist[3].getTarget(), "낮음");
+        test.equal(reslist[3].getTargetLocale(), "ko-KR");
+        test.equal(reslist[3].getKey(), "pictureControlLow_Male");
+        test.equal(reslist[3].getPath(), "settings");
+        test.equal(reslist[3].getProject(), "settings");
+        test.equal(reslist[3].resType, "string");
+        test.equal(reslist[3].datatype, "javascript");
+        test.ok(!reslist[3].getComment());
+        test.equal(reslist[3].getId(), "settings_1524");
+
+        test.equal(reslist[6].getSource(), "SEARCH");
+        test.equal(reslist[6].getSourceLocale(), "en-KR");
+        test.equal(reslist[6].getTarget(), "검색");
+        test.equal(reslist[6].getTargetLocale(), "ko-KR");
+        test.equal(reslist[6].getKey(), "SEARCH");
+        test.equal(reslist[6].getPath(), "settings");
+        test.equal(reslist[6].getProject(), "settings");
+        test.equal(reslist[6].resType, "string");
+        test.equal(reslist[6].datatype, "x-qml");
+        test.ok(reslist[6].getComment());
+        test.equal(reslist[6].getComment(), "copy strings from voice app");
+        test.equal(reslist[6].getId(), "settings_22");
+
+        test.done();
+    }
+    */
+};

--- a/webpack-test.config.js
+++ b/webpack-test.config.js
@@ -1,0 +1,58 @@
+/*
+ * webpack.config.js - webpack configuration script for ilib-env
+ *
+ * Copyright © 2021, JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+var webpack = require('webpack');
+var path = require('path');
+
+module.exports = {
+    mode: "development",
+    entry: "./test/testSuiteWeb.js",
+    output: {
+        path: path.resolve(__dirname, 'test'),
+        filename: "ilib-ctype-test.js",
+        library: {
+            name: "ilibCTypeTest",
+            type: "umd"
+        }
+    },
+    externals: {
+        'log4js': 'log4js'
+    },
+    devtool: false,
+    module: {
+        rules: [
+            {
+                test: /\.js$/,
+                exclude: /node_modules/,
+                include: /node_modules\/ilib-/,
+                use: {
+                    loader: 'babel-loader',
+                    options: {
+                        minified: false,
+                        compact: false,
+                        presets: ['@babel/preset-env'],
+                        plugins: ["add-module-exports"]
+                    }
+                }
+            }
+        ]
+    },
+    optimization: {
+        minimize: false
+    }
+};


### PR DESCRIPTION
Separating this into a separate project so that I can use it in other places. In loctool, you add and retrieve resources to/from the xliff. In this one, it is simpler. You can only add in translation units. Later, we'll change loctool to use this code, and add a layer on top of it that knows how to convert loctool resources into translation units and use this code to serialize/deserialize from there.