### PR TITLE
Add line count and location information for xml elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ limitations under the License.
 
 - add support for the "translate" flag on translation units
 - fixed the API documentation to be more useful
+- added getLines() method to count the number of lines in the original
+  xml if this is being used to parse the xliff file
 - added "location" information of the start of each translation unit
   in the xml file
     - gives line number and character within the line of each

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ limitations under the License.
 
 - add support for the "translate" flag on translation units
 - fixed the API documentation to be more useful
+- added "location" information of the start of each translation unit
+  in the xml file
+    - gives line number and character within the line of each
+      trans-unit (v1.2) or unit (v2.0) element in the file
 
 ### v1.0.0
 

--- a/package.json
+++ b/package.json
@@ -100,8 +100,7 @@
     "dependencies": {
         "ilib-common": "^1.1.3",
         "ilib-locale": "^1.2.2",
-        "ilib-xml-js": "file:../xml-js/ilib-xml-js-1.7.0.tgz",
-        "json5": "^2.2.1",
-        "xml-js": "^1.6.11"
+        "ilib-xml-js": "^1.7.0",
+        "json5": "^2.2.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "dist": "npm run build:prod ; npm pack",
         "test:cli": "LANG=en_US.UTF8 npm-run-all build:pkg build:dev ; bash test/testSuite.sh",
         "test:web": "LANG=en_US.UTF8 npm-run-all build:test ; open-cli ./test/testSuite.html ; open-cli ./test/testSuite.html -- firefox",
-        "test": "npm-run-all build:dev test:cli",
+        "test": "npm-run-all test:cli",
         "test:all": "npm-run-all test:cli test:web",
         "debug": "npm run build:dev ; node --inspect-brk test/testSuite.js",
         "clean": "git clean -f -d src test; rm -rf lib *.tgz",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "dependencies": {
         "ilib-common": "^1.1.3",
         "ilib-locale": "^1.2.2",
+        "ilib-xml-js": "file:../xml-js/ilib-xml-js-1.7.0.tgz",
         "json5": "^2.2.1",
         "xml-js": "^1.6.11"
     }

--- a/src/TranslationUnit.js
+++ b/src/TranslationUnit.js
@@ -42,6 +42,8 @@ class TranslationUnit {
      * <li><i>datatype</i> - the source of the data of this unit (optional)
      * <li><i>flavor</i> - the flavor that this string comes from (optional)
      * <li><i>translate</i> - flag that tells whether to translate this unit (optional)
+     * <li><i>location</i> - the line and character location of the start of this
+     * translation unit in the xml representation of the file
      * </ul>
      *
      * If the required properties are not given, the constructor throws an exception.<p>
@@ -60,14 +62,14 @@ class TranslationUnit {
             const everything = ["source", "sourceLocale", "key", "file", "project"].every((p) => {
                 return typeof(options[p]) !== "undefined";
             });
-    
+
             if (!everything) {
                 const missing = ["source", "sourceLocale", "key", "file", "project"].filter((p) => {
                     return typeof(options[p]) === "undefined";
                 });
                 throw new Error(`Missing required parameters in the TranslationUnit constructor: ${missing.join(", ")}`);
             }
-    
+
             for (let p in options) {
                 this[p] = options[p];
             }

--- a/src/Xliff.js
+++ b/src/Xliff.js
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import xmljs from 'xml-js';
+import xmljs from 'ilib-xml-js';
 import Locale from 'ilib-locale';
 import { JSUtils } from 'ilib-common';
 

--- a/src/Xliff.js
+++ b/src/Xliff.js
@@ -1,7 +1,7 @@
 /*
  * Xliff.js - model an xliff file
  *
- * Copyright © 2016-2017, 2019-2022 HealthTap, Inc. and JEDLSoft
+ * Copyright © 2016-2017, 2019-2023 HealthTap, Inc. and JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Xliff.js
+++ b/src/Xliff.js
@@ -1023,7 +1023,15 @@ class Xliff {
      * accurate after it has been serialized or deserialized.
      */
     getLines() {
-        return this.lines;
+        return this.lines || 0;
+    }
+
+    /**
+     * Return the number of bytes in the file. This is only really
+     * accurate after it has been serialized or deserialized.
+     */
+    getBytes() {
+        return this.fileLength || 0;
     }
 
     /**

--- a/test/testXliff12.js
+++ b/test/testXliff12.js
@@ -907,7 +907,7 @@ export const testXliff12 = {
     },
 
     testXliffDeserializeWithSourceOnly: function(test) {
-        test.expect(21);
+        test.expect(23);
 
         const x = new Xliff();
         test.ok(x);
@@ -946,6 +946,7 @@ export const testXliff12 = {
         test.equal(tulist[0].project, "androidapp");
         test.equal(tulist[0].resType, "string");
         test.equal(tulist[0].id, "1");
+        test.deepEqual(tulist[0].location, {line: 4, char: 7});
 
         test.equal(tulist[1].source, "baby baby");
         test.equal(tulist[1].sourceLocale, "en-US");
@@ -956,12 +957,13 @@ export const testXliff12 = {
         test.equal(tulist[1].project, "webapp");
         test.equal(tulist[1].resType, "string");
         test.equal(tulist[1].id, "2");
+        test.deepEqual(tulist[1].location, {line: 11, char: 7});
 
         test.done();
     },
 
     testXliffDeserializeWithSourceAndTarget: function(test) {
-        test.expect(21);
+        test.expect(23);
 
         const x = new Xliff();
         test.ok(x);
@@ -1004,6 +1006,7 @@ export const testXliff12 = {
         test.equal(tulist[0].id, "1");
         test.equal(tulist[0].target, "foobarfoo");
         test.equal(tulist[0].targetLocale, "de-DE");
+        test.deepEqual(tulist[0].location, {line: 4, char: 7});
 
         test.equal(tulist[1].source, "baby baby");
         test.equal(tulist[1].sourceLocale, "en-US");
@@ -1014,12 +1017,13 @@ export const testXliff12 = {
         test.equal(tulist[1].id, "2");
         test.equal(tulist[1].target, "bebe bebe");
         test.equal(tulist[1].targetLocale, "fr-FR");
+        test.deepEqual(tulist[1].location, {line: 12, char: 7});
 
         test.done();
     },
 
     testXliffDeserializeWithXMLUnescaping: function(test) {
-        test.expect(19);
+        test.expect(21);
 
         const x = new Xliff();
         test.ok(x);
@@ -1057,6 +1061,7 @@ export const testXliff12 = {
         test.equal(tulist[0].resType, "string");
         test.equal(tulist[0].id, "1");
         test.ok(!tulist[0].target);
+        test.deepEqual(tulist[0].location, {line: 4, char: 7});
 
         test.equal(tulist[1].source, "baby &lt;b&gt;baby&lt;/b&gt;");
         test.equal(tulist[1].sourceLocale, "en-US");
@@ -1066,6 +1071,7 @@ export const testXliff12 = {
         test.equal(tulist[1].resType, "string");
         test.equal(tulist[1].id, "2");
         test.ok(!tulist[1].target);
+        test.deepEqual(tulist[1].location, {line: 11, char: 7});
 
         test.done();
     },
@@ -1522,7 +1528,7 @@ export const testXliff12 = {
     },
 
     testXliffDeserializePreserveSourceWhitespace: function(test) {
-        test.expect(9);
+        test.expect(10);
 
         const x = new Xliff();
         test.ok(x);
@@ -1552,6 +1558,7 @@ export const testXliff12 = {
         test.equal(tulist[0].file, "UI/AddAnotherButtonView.m");
         test.equal(tulist[0].project, "iosapp");
         test.equal(tulist[0].resType, "string");
+        test.deepEqual(tulist[0].location, {line: 4, char: 7});
 
         test.done();
     },
@@ -1592,7 +1599,7 @@ export const testXliff12 = {
     },
 
     testXliffDeserializeStillAcceptsAnnotatesAttr: function(test) {
-        test.expect(19);
+        test.expect(21);
 
         const x = new Xliff({
             allowDups: true
@@ -1632,6 +1639,7 @@ export const testXliff12 = {
         test.equal(tulist[0].resType, "string");
         test.equal(tulist[0].context, "asdfasdf");
         test.equal(tulist[0].comment, "this is a comment");
+        test.deepEqual(tulist[0].location, {line: 4, char: 7});
 
         test.equal(tulist[1].target, "ababab");
         test.equal(tulist[1].targetLocale, "fr-FR");
@@ -1641,6 +1649,7 @@ export const testXliff12 = {
         test.equal(tulist[1].resType, "string");
         test.equal(tulist[1].context, "asdfasdf");
         test.equal(tulist[1].comment, "this is a different comment");
+        test.deepEqual(tulist[1].location, {line: 9, char: 7});
 
         test.done();
     },

--- a/test/testXliff12.js
+++ b/test/testXliff12.js
@@ -906,92 +906,6 @@ export const testXliff12 = {
         test.done();
     },
 
-    testXliffSerializeWithTranslateFlagFalse: function(test) {
-        test.expect(2);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        const tu = new TranslationUnit({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            target: "bam bam",
-            targetLocale: "de-DE",
-            key: "foobar",
-            file: "foo/bar/asdf.java",
-            project: "webapp",
-            resType: "string",
-            state: "new",
-            comment: "This is a comment",
-            datatype: "java",
-            translate: false
-        })
-
-        x.addTranslationUnit(tu);
-
-        let actual = x.serialize();
-        let expected =
-            '<?xml version="1.0" encoding="utf-8"?>\n' +
-            '<xliff version="1.2">\n' +
-            '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="webapp">\n' +
-            '    <body>\n' +
-            '      <trans-unit id="1" resname="foobar" restype="string" datatype="java" translate="false">\n' +
-            '        <source>Asdf asdf</source>\n' +
-            '        <target state="new">bam bam</target>\n' +
-            '        <note>This is a comment</note>\n' +
-            '      </trans-unit>\n' +
-            '    </body>\n' +
-            '  </file>\n' +
-            '</xliff>';
-
-        diff(actual, expected);
-        test.equal(actual, expected);
-        test.done();
-    },
-
-    testXliffSerializeWithTranslateFlagTrue: function(test) {
-        test.expect(2);
-
-        const x = new Xliff();
-        test.ok(x);
-
-        const tu = new TranslationUnit({
-            source: "Asdf asdf",
-            sourceLocale: "en-US",
-            target: "bam bam",
-            targetLocale: "de-DE",
-            key: "foobar",
-            file: "foo/bar/asdf.java",
-            project: "webapp",
-            resType: "string",
-            state: "new",
-            comment: "This is a comment",
-            datatype: "java",
-            translate: true
-        })
-
-        x.addTranslationUnit(tu);
-
-        let actual = x.serialize();
-        let expected =
-            '<?xml version="1.0" encoding="utf-8"?>\n' +
-            '<xliff version="1.2">\n' +
-            '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="webapp">\n' +
-            '    <body>\n' +
-            '      <trans-unit id="1" resname="foobar" restype="string" datatype="java">\n' +
-            '        <source>Asdf asdf</source>\n' +
-            '        <target state="new">bam bam</target>\n' +
-            '        <note>This is a comment</note>\n' +
-            '      </trans-unit>\n' +
-            '    </body>\n' +
-            '  </file>\n' +
-            '</xliff>';
-
-        diff(actual, expected);
-        test.equal(actual, expected);
-        test.done();
-    },
-
     testXliffDeserializeWithSourceOnly: function(test) {
         test.expect(21);
 
@@ -1047,7 +961,7 @@ export const testXliff12 = {
     },
 
     testXliffDeserializeWithSourceAndTarget: function(test) {
-        test.expect(23);
+        test.expect(21);
 
         const x = new Xliff();
         test.ok(x);
@@ -1090,7 +1004,6 @@ export const testXliff12 = {
         test.equal(tulist[0].id, "1");
         test.equal(tulist[0].target, "foobarfoo");
         test.equal(tulist[0].targetLocale, "de-DE");
-        test.equal(typeof(tulist[0].translate), 'undefined');
 
         test.equal(tulist[1].source, "baby baby");
         test.equal(tulist[1].sourceLocale, "en-US");
@@ -1101,7 +1014,6 @@ export const testXliff12 = {
         test.equal(tulist[1].id, "2");
         test.equal(tulist[1].target, "bebe bebe");
         test.equal(tulist[1].targetLocale, "fr-FR");
-        test.equal(typeof(tulist[1].translate), 'undefined');
 
         test.done();
     },
@@ -1729,6 +1641,92 @@ export const testXliff12 = {
         test.equal(tulist[1].resType, "string");
         test.equal(tulist[1].context, "asdfasdf");
         test.equal(tulist[1].comment, "this is a different comment");
+
+        test.done();
+    },
+
+    testXliffGetLinesDefault: function(test) {
+        test.expect(2);
+
+        const x = new Xliff({
+            allowDups: true
+        });
+        test.ok(x);
+
+        // default value
+        test.equal(x.getLines(), 0);
+        test.done();
+    },
+
+    testXliffGetLinesDeserialize: function(test) {
+        test.expect(3);
+
+        const x = new Xliff({
+            allowDups: true
+        });
+        test.ok(x);
+
+        test.equal(x.getLines(), 0);
+
+        x.deserialize(
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="1.2">\n' +
+            '  <file original="/a/b/asdf.js" source-language="en-US" target-language="fr-FR" product-name="iosapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="2333" resname="asdf" restype="string" x-context="asdfasdf">\n' +
+            '        <source>bababa</source>\n' +
+            '        <target>ababab</target>\n' +
+            '        <note annotates="source">this is a comment</note>\n' +
+            '      </trans-unit>\n' +
+            '      <trans-unit id="2334" resname="asdf" restype="string" x-context="asdfasdf">\n' +
+            '        <source>bababa</source>\n' +
+            '        <target>ababab</target>\n' +
+            '        <note annotates="source">this is a different comment</note>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '</xliff>');
+
+        test.equal(x.getLines(), 17);
+        test.done();
+    },
+
+    testXliffGetLinesSerialize: function(test) {
+        test.expect(4);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        test.equal(x.getLines(), 0);
+
+        x.addTranslationUnits([
+            new TranslationUnit({
+                source: "Asdf asdf",
+                sourceLocale: "en-US",
+                target: "Asdf",
+                targetLocale: "de-DE",
+                key: 'foobar asdf',
+                file: "foo/bar/asdf.java",
+                project: "androidapp",
+                origin: "target",
+                datatype: "plaintext"
+            }),
+            new TranslationUnit({
+                source: "baby baby",
+                sourceLocale: "en-US",
+                target: "baby",
+                targetLocale: "de-DE",
+                key: "huzzah asdf test",
+                file: "foo/bar/j.java",
+                project: "webapp",
+                origin: "target",
+                datatype: "plaintext"
+            })
+        ]);
+
+        let actual = x.serialize();
+        test.ok(actual);
+        test.equal(x.getLines(), 19);
 
         test.done();
     },

--- a/test/testXliff12.js
+++ b/test/testXliff12.js
@@ -1755,6 +1755,19 @@ export const testXliff12 = {
         test.done();
     },
 
+    testXliffGetBytesDefault: function(test) {
+        test.expect(2);
+
+        const x = new Xliff({
+            allowDups: true
+        });
+        test.ok(x);
+
+        // default value
+        test.equal(x.getBytes(), 0);
+        test.done();
+    },
+
     testXliffGetLinesDeserialize: function(test) {
         test.expect(3);
 
@@ -1824,6 +1837,79 @@ export const testXliff12 = {
         let actual = x.serialize();
         test.ok(actual);
         test.equal(x.getLines(), 19);
+
+        test.done();
+    },
+
+    testXliffGetBytesDeserialize: function(test) {
+        test.expect(3);
+
+        const x = new Xliff({
+            allowDups: true
+        });
+        test.ok(x);
+
+        test.equal(x.getBytes(), 0);
+
+        x.deserialize(
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="1.2">\n' +
+            '  <file original="/a/b/asdf.js" source-language="en-US" target-language="fr-FR" product-name="iosapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="2333" resname="asdf" restype="string" x-context="asdfasdf">\n' +
+            '        <source>bababa</source>\n' +
+            '        <target>ababab</target>\n' +
+            '        <note annotates="source">this is a comment</note>\n' +
+            '      </trans-unit>\n' +
+            '      <trans-unit id="2334" resname="asdf" restype="string" x-context="asdfasdf">\n' +
+            '        <source>bababa</source>\n' +
+            '        <target>ababab</target>\n' +
+            '        <note annotates="source">this is a different comment</note>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '</xliff>');
+
+        test.equal(x.getBytes(), 663);
+        test.done();
+    },
+
+    testXliffGetBytesSerialize: function(test) {
+        test.expect(4);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        test.equal(x.getBytes(), 0);
+
+        x.addTranslationUnits([
+            new TranslationUnit({
+                source: "Asdf asdf",
+                sourceLocale: "en-US",
+                target: "Asdf",
+                targetLocale: "de-DE",
+                key: 'foobar asdf',
+                file: "foo/bar/asdf.java",
+                project: "androidapp",
+                origin: "target",
+                datatype: "plaintext"
+            }),
+            new TranslationUnit({
+                source: "baby baby",
+                sourceLocale: "en-US",
+                target: "baby",
+                targetLocale: "de-DE",
+                key: "huzzah asdf test",
+                file: "foo/bar/j.java",
+                project: "webapp",
+                origin: "target",
+                datatype: "plaintext"
+            })
+        ]);
+
+        let actual = x.serialize();
+        test.ok(actual);
+        test.equal(x.getBytes(), 699);
 
         test.done();
     },

--- a/test/testXliff12.js
+++ b/test/testXliff12.js
@@ -906,6 +906,92 @@ export const testXliff12 = {
         test.done();
     },
 
+    testXliffSerializeWithTranslateFlagFalse: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        const tu = new TranslationUnit({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            target: "bam bam",
+            targetLocale: "de-DE",
+            key: "foobar",
+            file: "foo/bar/asdf.java",
+            project: "webapp",
+            resType: "string",
+            state: "new",
+            comment: "This is a comment",
+            datatype: "java",
+            translate: false
+        })
+
+        x.addTranslationUnit(tu);
+
+        let actual = x.serialize();
+        let expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="1.2">\n' +
+            '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="webapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="1" resname="foobar" restype="string" datatype="java" translate="false">\n' +
+            '        <source>Asdf asdf</source>\n' +
+            '        <target state="new">bam bam</target>\n' +
+            '        <note>This is a comment</note>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXliffSerializeWithTranslateFlagTrue: function(test) {
+        test.expect(2);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        const tu = new TranslationUnit({
+            source: "Asdf asdf",
+            sourceLocale: "en-US",
+            target: "bam bam",
+            targetLocale: "de-DE",
+            key: "foobar",
+            file: "foo/bar/asdf.java",
+            project: "webapp",
+            resType: "string",
+            state: "new",
+            comment: "This is a comment",
+            datatype: "java",
+            translate: true
+        })
+
+        x.addTranslationUnit(tu);
+
+        let actual = x.serialize();
+        let expected =
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="1.2">\n' +
+            '  <file original="foo/bar/asdf.java" source-language="en-US" target-language="de-DE" product-name="webapp">\n' +
+            '    <body>\n' +
+            '      <trans-unit id="1" resname="foobar" restype="string" datatype="java">\n' +
+            '        <source>Asdf asdf</source>\n' +
+            '        <target state="new">bam bam</target>\n' +
+            '        <note>This is a comment</note>\n' +
+            '      </trans-unit>\n' +
+            '    </body>\n' +
+            '  </file>\n' +
+            '</xliff>';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
     testXliffDeserializeWithSourceOnly: function(test) {
         test.expect(23);
 
@@ -963,7 +1049,7 @@ export const testXliff12 = {
     },
 
     testXliffDeserializeWithSourceAndTarget: function(test) {
-        test.expect(23);
+        test.expect(25);
 
         const x = new Xliff();
         test.ok(x);
@@ -1006,6 +1092,7 @@ export const testXliff12 = {
         test.equal(tulist[0].id, "1");
         test.equal(tulist[0].target, "foobarfoo");
         test.equal(tulist[0].targetLocale, "de-DE");
+        test.equal(typeof(tulist[0].translate), 'undefined');
         test.deepEqual(tulist[0].location, {line: 4, char: 7});
 
         test.equal(tulist[1].source, "baby baby");
@@ -1017,6 +1104,7 @@ export const testXliff12 = {
         test.equal(tulist[1].id, "2");
         test.equal(tulist[1].target, "bebe bebe");
         test.equal(tulist[1].targetLocale, "fr-FR");
+        test.equal(typeof(tulist[1].translate), 'undefined');
         test.deepEqual(tulist[1].location, {line: 12, char: 7});
 
         test.done();

--- a/test/testXliff20.js
+++ b/test/testXliff20.js
@@ -1023,7 +1023,7 @@ export const testXliff20 = {
     },
 
     testXliff20DeserializeWithSourceOnly: function(test) {
-        test.expect(23);
+        test.expect(25);
 
         const x = new Xliff({version: 2.0});
         test.ok(x);
@@ -1064,6 +1064,7 @@ export const testXliff20 = {
         test.equal(tulist[0].resType, "string");
         test.equal(tulist[0].id, "1");
         test.equal(typeof(tulist[0].translate), 'undefined');
+        test.deepEqual(tulist[0].location, {line: 4, char: 5});
 
         test.equal(tulist[1].source, "baby baby");
         test.equal(tulist[1].sourceLocale, "en-US");
@@ -1075,12 +1076,13 @@ export const testXliff20 = {
         test.equal(tulist[1].resType, "string");
         test.equal(tulist[1].id, "2");
         test.equal(typeof(tulist[1].translate), 'undefined');
+        test.deepEqual(tulist[1].location, {line: 11, char: 5});
 
         test.done();
     },
 
     testXliff20DeserializeWithSourceAndTarget: function(test) {
-        test.expect(21);
+        test.expect(23);
 
         const x = new Xliff({version: 2.0});
         test.ok(x);
@@ -1123,6 +1125,7 @@ export const testXliff20 = {
         test.equal(tulist[0].id, "1");
         test.equal(tulist[0].target, "foobarfoo");
         test.equal(tulist[0].targetLocale, "de-DE");
+        test.deepEqual(tulist[0].location, {line: 3, char: 5});
 
         test.equal(tulist[1].source, "baby baby");
         test.equal(tulist[1].sourceLocale, "en-US");
@@ -1133,6 +1136,7 @@ export const testXliff20 = {
         test.equal(tulist[1].id, "2");
         test.equal(tulist[1].target, "bebe bebe");
         test.equal(tulist[1].targetLocale, "de-DE");
+        test.deepEqual(tulist[1].location, {line: 11, char: 5});
 
         test.done();
     },

--- a/test/testXliff20.js
+++ b/test/testXliff20.js
@@ -1723,7 +1723,8 @@ export const testXliff20 = {
         test.expect(19);
 
         const x = new Xliff({
-            allowDups: true
+            allowDups: true,
+            version: 2.0
         });
         test.ok(x);
 
@@ -1775,6 +1776,99 @@ export const testXliff20 = {
         test.equal(tulist[1].resType, "string");
         test.equal(tulist[1].context, "asdfasdf");
         test.equal(tulist[1].comment, "this is a different comment");
+
+        test.done();
+    },
+    testXliffGetLinesDefault: function(test) {
+        test.expect(2);
+
+        const x = new Xliff({
+            allowDups: true,
+            version: 2.0
+        });
+        test.ok(x);
+
+        // default value
+        test.equal(x.getLines(), 0);
+        test.done();
+    },
+
+    testXliffGetLinesDeserialize: function(test) {
+        test.expect(3);
+
+        const x = new Xliff({
+            allowDups: true,
+            version: 2.0
+        });
+        test.ok(x);
+
+        test.equal(x.getLines(), 0);
+
+        x.deserialize(
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="2.0" srcLang="en-US" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">\n' +
+            '  <file original="/a/b/asdf.js" l:project="iosapp">\n' +
+            '    <unit id="2333" name="asdf" type="res:string" l:context="asdfasdf">\n' +
+            '      <notes>\n' +
+            '        <note appliesTo="source">this is a comment</note>\n' +
+            '      </notes>\n' +
+            '      <segment>\n' +
+            '        <source>bababa</source>\n' +
+            '        <target>ababab</target>\n' +
+            '      </segment>\n' +
+            '    </unit>\n' +
+            '    <unit id="2334" name="asdf" type="res:string" l:context="asdfasdf">\n' +
+            '      <notes>\n' +
+            '        <note appliesTo="target">this is a different comment</note>\n' +
+            '      </notes>\n' +
+            '      <segment>\n' +
+            '        <source>bababa</source>\n' +
+            '        <target>ababab</target>\n' +
+            '      </segment>\n' +
+            '    </unit>\n' +
+            '  </file>\n' +
+            '</xliff>');
+
+        test.equal(x.getLines(), 23);
+        test.done();
+    },
+
+    testXliffGetLinesSerialize: function(test) {
+        test.expect(4);
+
+        const x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        test.equal(x.getLines(), 0);
+
+        x.addTranslationUnits([
+            new TranslationUnit({
+                source: "Asdf asdf",
+                sourceLocale: "en-US",
+                target: "Asdf",
+                targetLocale: "de-DE",
+                key: 'foobar asdf',
+                file: "foo/bar/asdf.java",
+                project: "androidapp",
+                origin: "target",
+                datatype: "plaintext"
+            }),
+            new TranslationUnit({
+                source: "baby baby",
+                sourceLocale: "en-US",
+                target: "baby",
+                targetLocale: "de-DE",
+                key: "huzzah asdf test",
+                file: "foo/bar/j.java",
+                project: "webapp",
+                origin: "target",
+                datatype: "plaintext"
+            })
+        ]);
+
+        let actual = x.serialize();
+        test.ok(actual);
+        test.equal(x.getLines(), 23);
 
         test.done();
     },

--- a/test/testXliff20.js
+++ b/test/testXliff20.js
@@ -1783,6 +1783,7 @@ export const testXliff20 = {
 
         test.done();
     },
+
     testXliffGetLinesDefault: function(test) {
         test.expect(2);
 
@@ -1794,6 +1795,20 @@ export const testXliff20 = {
 
         // default value
         test.equal(x.getLines(), 0);
+        test.done();
+    },
+
+    testXliffGetBytesDefault: function(test) {
+        test.expect(2);
+
+        const x = new Xliff({
+            allowDups: true,
+            version: 2.0
+        });
+        test.ok(x);
+
+        // default value
+        test.equal(x.getBytes(), 0);
         test.done();
     },
 
@@ -1873,6 +1888,86 @@ export const testXliff20 = {
         let actual = x.serialize();
         test.ok(actual);
         test.equal(x.getLines(), 23);
+
+        test.done();
+    },
+
+    testXliffGetBytesDeserialize: function(test) {
+        test.expect(3);
+
+        const x = new Xliff({
+            allowDups: true,
+            version: 2.0
+        });
+        test.ok(x);
+
+        test.equal(x.getBytes(), 0);
+
+        x.deserialize(
+            '<?xml version="1.0" encoding="utf-8"?>\n' +
+            '<xliff version="2.0" srcLang="en-US" trgLang="fr-FR" xmlns:l="http://ilib-js.com/loctool">\n' +
+            '  <file original="/a/b/asdf.js" l:project="iosapp">\n' +
+            '    <unit id="2333" name="asdf" type="res:string" l:context="asdfasdf">\n' +
+            '      <notes>\n' +
+            '        <note appliesTo="source">this is a comment</note>\n' +
+            '      </notes>\n' +
+            '      <segment>\n' +
+            '        <source>bababa</source>\n' +
+            '        <target>ababab</target>\n' +
+            '      </segment>\n' +
+            '    </unit>\n' +
+            '    <unit id="2334" name="asdf" type="res:string" l:context="asdfasdf">\n' +
+            '      <notes>\n' +
+            '        <note appliesTo="target">this is a different comment</note>\n' +
+            '      </notes>\n' +
+            '      <segment>\n' +
+            '        <source>bababa</source>\n' +
+            '        <target>ababab</target>\n' +
+            '      </segment>\n' +
+            '    </unit>\n' +
+            '  </file>\n' +
+            '</xliff>');
+
+        test.equal(x.getBytes(), 746);
+        test.done();
+    },
+
+    testXliffGetBytesSerialize: function(test) {
+        test.expect(4);
+
+        const x = new Xliff({version: 2.0});
+        test.ok(x);
+
+        test.equal(x.getBytes(), 0);
+
+        x.addTranslationUnits([
+            new TranslationUnit({
+                source: "Asdf asdf",
+                sourceLocale: "en-US",
+                target: "Asdf",
+                targetLocale: "de-DE",
+                key: 'foobar asdf',
+                file: "foo/bar/asdf.java",
+                project: "androidapp",
+                origin: "target",
+                datatype: "plaintext"
+            }),
+            new TranslationUnit({
+                source: "baby baby",
+                sourceLocale: "en-US",
+                target: "baby",
+                targetLocale: "de-DE",
+                key: "huzzah asdf test",
+                file: "foo/bar/j.java",
+                project: "webapp",
+                origin: "target",
+                datatype: "plaintext"
+            })
+        ]);
+
+        let actual = x.serialize();
+        test.ok(actual);
+        test.equal(x.getBytes(), 788);
 
         test.done();
     },


### PR DESCRIPTION
- added Xliff.getLines() to tell how many lines there are
- added location information from ilib-xml-js for the start of each trans-unit or unit tag
    - depends on the new ilib-xml-js. CI/CD will fail until it is published.
- bumped v1.0.0 -> v1.1.0 because of the new feature