### PR TITLE
Add support for parsing inline elements and CDATA in XLIFF 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ limitations under the License.
 
 ## Release Notes
 
+### v1.2.0
+- added support for parsing inline content markup in XLIFF 1.2 (`<x />` etc.)
+- added support for parsing CDATA content in XLIFF 1.2 (`<![CDATA[<foo />]]>`)
+
 ### v1.1.0
 
 - add support for the "translate" flag on translation units

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-xliff",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "main": "./lib/index.js",
     "module": "./src/index.js",
     "exports": {

--- a/src/Xliff.js
+++ b/src/Xliff.js
@@ -781,6 +781,13 @@ class Xliff {
                 return String(el.text);
             }
 
+            if (el.type === "cdata") {
+                if (el.cdata === undefined) {
+                    return undefined;
+                }
+                return el.cdata;
+            }
+
             if (el.type === "element") {
                 // recurse into child elements
                 const content = el.elements

--- a/src/XmlUtil.js
+++ b/src/XmlUtil.js
@@ -8,7 +8,7 @@
  */
 export const getAttribute = (element, attrName) => {
     const value = element?.attributes?.[attrName];
-    if (value) {
+    if (value !== undefined) {
         return String(value);
     } else {
         return undefined;
@@ -23,7 +23,7 @@ export const getAttribute = (element, attrName) => {
  * @returns {string | undefined}
  */
 export const getText = (element) => {
-    if (!element) {
+    if (element === undefined) {
         return undefined;
     }
     const textElement = element.elements?.find((e) => e.type === "text");

--- a/src/XmlUtil.js
+++ b/src/XmlUtil.js
@@ -1,6 +1,6 @@
 /**
- * Return value of a specified attribute from a supplied xml element converted
- * to a string. If the attribute is not found, undefined is returned.
+ * Return value of a specified attribute from a supplied xml element converted to a string. If the attribute is not
+ * found, undefined is returned.
  *
  * @param {import("ilib-xml-js").Element | undefined} element
  * @param {string} attrName
@@ -16,8 +16,8 @@ export const getAttribute = (element, attrName) => {
 };
 
 /**
- * Return value of the first text element from a supplied xml element converted
- * to a string. If the text element is not found, undefined is returned.
+ * Return value of the first text element from a supplied xml element converted to a string. If the text element is not
+ * found, undefined is returned.
  *
  * @param {import("ilib-xml-js").Element | undefined} element
  * @returns {string | undefined}
@@ -35,12 +35,12 @@ export const getText = (element) => {
 };
 
 /**
- * Return array of elements with a specified name from a supplied xml element
- * or undefined if the element is not found or has no children.
+ * Return array of elements with a specified name from a supplied xml element or undefined if the element is not found
+ * or has no children.
  *
  * @param {import("ilib-xml-js").Element | undefined} element
  * @param {string} elName
- * @returns {import("ilib-xml-js").Element[] | undefined} 
+ * @returns {import("ilib-xml-js").Element[] | undefined}
  */
 export const getChildrenByName = (element, elName) => {
     return element?.elements?.filter((e) => e.name === elName);

--- a/src/XmlUtil.js
+++ b/src/XmlUtil.js
@@ -1,0 +1,47 @@
+/**
+ * Return value of a specified attribute from a supplied xml element converted
+ * to a string. If the attribute is not found, undefined is returned.
+ *
+ * @param {import("ilib-xml-js").Element | undefined} element
+ * @param {string} attrName
+ * @returns {string | undefined}
+ */
+export const getAttribute = (element, attrName) => {
+    const value = element?.attributes?.[attrName];
+    if (value) {
+        return String(value);
+    } else {
+        return undefined;
+    }
+};
+
+/**
+ * Return value of the first text element from a supplied xml element converted
+ * to a string. If the text element is not found, undefined is returned.
+ *
+ * @param {import("ilib-xml-js").Element | undefined} element
+ * @returns {string | undefined}
+ */
+export const getText = (element) => {
+    if (!element) {
+        return undefined;
+    }
+    const textElement = element.elements?.find((e) => e.type === "text");
+    if (textElement) {
+        return String(textElement.text ?? "");
+    } else {
+        return undefined;
+    }
+};
+
+/**
+ * Return array of elements with a specified name from a supplied xml element
+ * or undefined if the element is not found or has no children.
+ *
+ * @param {import("ilib-xml-js").Element | undefined} element
+ * @param {string} elName
+ * @returns {import("ilib-xml-js").Element[] | undefined} 
+ */
+export const getChildrenByName = (element, elName) => {
+    return element?.elements?.filter((e) => e.name === elName);
+};

--- a/test/testXliff12.js
+++ b/test/testXliff12.js
@@ -1615,6 +1615,45 @@ export const testXliff12 = {
         test.done();
     },
 
+    testXliffDeserializeWithXTagInSource: function(test) {
+        test.expect(12);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>Less-than sign (<x id="1" equiv-text="&lt;"/>) is not allowed in XLIFF.</source>\n' +
+                '        <target>Le signe inférieur (&lt;) n\'est pas autorisé dans XLIFF.</target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+
+        test.equal(tulist[0].source, "Less-than sign (<) is not allowed in XLIFF.");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "huzzah");
+        test.equal(tulist[0].file, "foo/bar/j.java");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "2");
+
+        test.equal(tulist[0].target, "Le signe inférieur (<) n\'est pas autorisé dans XLIFF.");
+        test.equal(tulist[0].targetLocale, "fr-FR");
+
+        test.done();
+    },
+
     testXliffDeserializePreserveSourceWhitespace: function(test) {
         test.expect(10);
 

--- a/test/testXliff12.js
+++ b/test/testXliff12.js
@@ -1853,6 +1853,44 @@ export const testXliff12 = {
         test.done();
     },
 
+    testXliffDeserializeWithCdata: function(test) {
+        test.expect(12);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source><![CDATA[In CDATA sections, even the less-than sign < is allowed.]]></source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+
+        test.equal(tulist[0].source, "In CDATA sections, even the less-than sign < is allowed.");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "huzzah");
+        test.equal(tulist[0].file, "foo/bar/j.java");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "2");
+
+        test.ok(!tulist[0].target);
+        test.equal(tulist[0].targetLocale, "");
+
+        test.done();
+    },
+
     testXliffDeserializePreserveSourceWhitespace: function(test) {
         test.expect(10);
 

--- a/test/testXliff12.js
+++ b/test/testXliff12.js
@@ -1539,7 +1539,7 @@ export const testXliff12 = {
         test.done();
     },
 
-    testXliffDeserializeWithMultipleMrkTagsInTargetEuro: function(test) {
+    testXliffDeserializeWithMultipleMrkTagsInTarget: function(test) {
         test.expect(12);
 
         const x = new Xliff();
@@ -1608,9 +1608,88 @@ export const testXliff12 = {
         test.equal(tulist[0].project, "webapp");
         test.equal(tulist[0].resType, "string");
         test.equal(tulist[0].id, "2");
-
-        test.equal(tulist[0].target, "This is segment 1.This is segment 2.This is segment 3.");
+        // regardless of the target locale, preserve whitespace between mrk tags if it exists
+        test.equal(tulist[0].target, "This is segment 1. This is segment 2. This is segment 3.");
         test.equal(tulist[0].targetLocale, "zh-Hans-CN");
+
+        test.done();
+    },
+
+    testXliffDeserializePreserveWhitespaceBetweenInlineElementsInSource: function(test) {
+        test.expect(12);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source><g id="1">This is group 1.</g>\n<g id="2">This is group 2.</g> <g id="3">This is group 3.</g></source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+
+        test.equal(tulist[0].source, "This is group 1.\nThis is group 2. This is group 3.");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "huzzah");
+        test.equal(tulist[0].file, "foo/bar/j.java");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "2");
+
+        test.ok(!tulist[0].target);
+        test.equal(tulist[0].targetLocale, "");
+
+        test.done();
+    },
+
+    testXliffDeserializePreserveWhitespaceBetweenInlineElementsInTarget: function(test) {
+        test.expect(12);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>baby baby</source>\n' +
+                '        <seg-source><mrk mtype="seg" mid="4">baby baby</mrk></seg-source>\n'+
+                '        <target><mrk mtype="seg" mid="4">This is segment 1.</mrk>\n'+
+                '<mrk mtype="seg" mid="5">This is segment 2.</mrk> <mrk mtype="seg" mid="6">This is segment 3.</mrk></target>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+
+        test.equal(tulist[0].source, "baby baby");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "huzzah");
+        test.equal(tulist[0].file, "foo/bar/j.java");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "2");
+
+        test.equal(tulist[0].target, "This is segment 1.\nThis is segment 2. This is segment 3.");
+        test.equal(tulist[0].targetLocale, "fr-FR");
 
         test.done();
     },
@@ -1624,11 +1703,49 @@ export const testXliff12 = {
         x.deserialize(
                 '<?xml version="1.0" encoding="utf-8"?>\n' +
                 '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>Less-than sign (<x id="1" equiv-text="&lt;"/>) is not allowed in XLIFF.</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+
+        test.equal(tulist[0].source, "Less-than sign (<) is not allowed in XLIFF.");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "huzzah");
+        test.equal(tulist[0].file, "foo/bar/j.java");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "2");
+
+        test.ok(!tulist[0].target);
+        test.equal(tulist[0].targetLocale, "");
+
+        test.done();
+    },
+
+    testXliffDeserializeWithXTagInSourceAndTarget: function(test) {
+        test.expect(12);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
                 '  <file original="foo/bar/j.java" source-language="en-US" target-language="fr-FR" product-name="webapp">\n' +
                 '    <body>\n' +
                 '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
                 '        <source>Less-than sign (<x id="1" equiv-text="&lt;"/>) is not allowed in XLIFF.</source>\n' +
-                '        <target>Le signe inférieur (&lt;) n\'est pas autorisé dans XLIFF.</target>\n' +
+                '        <target>Le signe inférieur (<x id="1" equiv-text="&lt;"/>) n\'est pas autorisé dans XLIFF.</target>\n' +
                 '      </trans-unit>\n' +
                 '    </body>\n' +
                 '  </file>\n' +
@@ -1650,6 +1767,88 @@ export const testXliff12 = {
 
         test.equal(tulist[0].target, "Le signe inférieur (<) n\'est pas autorisé dans XLIFF.");
         test.equal(tulist[0].targetLocale, "fr-FR");
+
+        test.done();
+    },
+
+    testXliffDeserializeInlineTagWithContent: function(test) {
+        test.expect(12);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        // example based on https://www.gala-global.org/tmx-14b:
+        // <B>Bold <I>Bold and Italic</B> Italics</I>
+        //
+        // note that non-well-formedness is intentional here (as per the XLIFF spec for <bpt> and <ept> elements)
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source><bpt id="1">&lt;B></bpt>Bold <bpt id="2">&lt;I></bpt>Bold and Italic<ept id="1">&lt;/B></ept> Italics<ept id="2">&lt;/I></ept></source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+
+        test.equal(tulist[0].source, "<B>Bold <I>Bold and Italic</B> Italics</I>");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "huzzah");
+        test.equal(tulist[0].file, "foo/bar/j.java");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "2");
+
+        test.ok(!tulist[0].target);
+        test.equal(tulist[0].targetLocale, "");
+
+        test.done();
+    },
+
+    testXliffDeserializeInlineTagPreferContentOverEquivText: function(test) {
+        test.expect(12);
+
+        const x = new Xliff();
+        test.ok(x);
+
+        // example based on https://www.gala-global.org/tmx-14b:
+        // The icon <img src="testNode.gif"/> represents a conditional node.
+        x.deserialize(
+                '<?xml version="1.0" encoding="utf-8"?>\n' +
+                '<xliff version="1.2">\n' +
+                '  <file original="foo/bar/j.java" source-language="en-US" target-language="" product-name="webapp">\n' +
+                '    <body>\n' +
+                '      <trans-unit id="2" resname="huzzah" restype="string">\n' +
+                '        <source>The icon <ph x="1" equiv-text="">&lt;img src="testNode.gif"/></ph> represents a conditional node.</source>\n' +
+                '      </trans-unit>\n' +
+                '    </body>\n' +
+                '  </file>\n' +
+                '</xliff>');
+
+        let tulist = x.getTranslationUnits();
+
+        test.ok(tulist);
+
+        test.equal(tulist.length, 1);
+
+        test.equal(tulist[0].source, "The icon <img src=\"testNode.gif\"/> represents a conditional node.");
+        test.equal(tulist[0].sourceLocale, "en-US");
+        test.equal(tulist[0].key, "huzzah");
+        test.equal(tulist[0].file, "foo/bar/j.java");
+        test.equal(tulist[0].project, "webapp");
+        test.equal(tulist[0].resType, "string");
+        test.equal(tulist[0].id, "2");
+
+        test.ok(!tulist[0].target);
+        test.equal(tulist[0].targetLocale, "");
 
         test.done();
     },


### PR DESCRIPTION
Fixes parsing of xliff 1.2 documents in which `<souce>` or `<target>` elements of `<trans-unit>`s contain:
* content markup (inline elements) like `<x id="1" equiv-text="&lt;" />`
* cdata `<![CDATA[<a href>]]>`
Before that, parser would throw an error if it encountered content which is not text-only.

In order to preserve existing API of the plugin (specifically interface of `TransUnit` which only deals with string values), only parsing of such content is supported and all markup is stringified. To preserve original data as much as possible, each inline element is replaced with either descendant text elements, or - if no descendant text is found - falls back to the value of `equiv-text` attribute. See unit tests for detailed examples.